### PR TITLE
2.2.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1043,3 +1043,7 @@ All notable changes to this project will be documented in this file.
 
 - add NaN check for numeric literal scan in order to show syntax errors on invalid numbers - thanks for reporting c1ph3r
 - include lexer exceptions in diagnostics
+
+## [2.2.22] - 05.04.2024
+
+- ignore return statement when it's not within function scope

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1048,3 +1048,5 @@ All notable changes to this project will be documented in this file.
 
 - ignore return statement when it's not within function scope
 - remove any limitations from the vscode web version since everything seems to be compatible with code serve-web
+- fix hover import and includes with missing extension
+- fix document-manager for includes and imports without file extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1047,3 +1047,4 @@ All notable changes to this project will be documented in this file.
 ## [2.2.22] - 05.04.2024
 
 - ignore return statement when it's not within function scope
+- remove any limitations from the vscode web version since everything seems to be compatible with code serve-web

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "greybel-vs",
-    "version": "2.2.21",
+    "version": "2.2.22",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "greybel-vs",
-            "version": "2.2.21",
+            "version": "2.2.22",
             "dependencies": {
                 "@vscode/debugadapter": "^1.51.1",
                 "@vscode/debugprotocol": "^1.51.0",
@@ -16,10 +16,10 @@
                 "comment-parser": "^1.4.1",
                 "css-color-names": "^1.0.1",
                 "greybel-agent": "~1.7.0",
-                "greybel-gh-mock-intrinsics": "~4.7.7",
-                "greybel-intrinsics": "~4.6.6",
+                "greybel-gh-mock-intrinsics": "~4.7.8",
+                "greybel-intrinsics": "~4.6.7",
                 "greyscript-core": "~1.5.13",
-                "greyscript-interpreter": "~1.6.5",
+                "greyscript-interpreter": "~1.6.6",
                 "greyscript-meta": "~2.4.1",
                 "greyscript-textmate": "~1.8.0",
                 "greyscript-transpiler": "~0.6.12",
@@ -5151,19 +5151,19 @@
             }
         },
         "node_modules/greybel-gh-mock-intrinsics": {
-            "version": "4.7.7",
-            "resolved": "https://registry.npmjs.org/greybel-gh-mock-intrinsics/-/greybel-gh-mock-intrinsics-4.7.7.tgz",
-            "integrity": "sha512-7zYNTPo/8D7yYQtjeuu9fv9JTxnb/zagRxi75cxg1TOuInsOzRLepiCmqGPIUhPPhlJnKYUkD31+rTtuesrCDg==",
+            "version": "4.7.8",
+            "resolved": "https://registry.npmjs.org/greybel-gh-mock-intrinsics/-/greybel-gh-mock-intrinsics-4.7.8.tgz",
+            "integrity": "sha512-lktsvhpEjKk/qaRLcCq1TYJ/gYg6hQ2GsuPhSK0PCaKlBP6oBEQqZZRhdKGhuEXYEgmUAGKY42wZ0FEdJRVI/w==",
             "dependencies": {
                 "blueimp-md5": "^2.19.0",
                 "greybel-mock-environment": "~2.4.15",
-                "greyscript-interpreter": "~1.6.5"
+                "greyscript-interpreter": "~1.6.6"
             }
         },
         "node_modules/greybel-interpreter": {
-            "version": "4.5.12",
-            "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-4.5.12.tgz",
-            "integrity": "sha512-NAuuua89CijSzAgHDTKn3FL+jGjjD4pKWSONHLA4Vp/ZW4lhXAnzIIn6rP3ucO5yBV+nZlpuxNf3PXi75tRj6g==",
+            "version": "4.5.13",
+            "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-4.5.13.tgz",
+            "integrity": "sha512-ky1sNM8YJ4e3v8hGRVB+Uz7NLzpy6Y/brVDbJeB8KDTPuTnb7MbEJhPXcNKGDU2zz2KwtBoKbaojPPaSKJ/ECQ==",
             "dependencies": {
                 "greybel-core": "~1.5.13",
                 "lru-cache": "^10.0.1"
@@ -5178,11 +5178,11 @@
             }
         },
         "node_modules/greybel-intrinsics": {
-            "version": "4.6.6",
-            "resolved": "https://registry.npmjs.org/greybel-intrinsics/-/greybel-intrinsics-4.6.6.tgz",
-            "integrity": "sha512-PEO1xZ0OlCGNKiCvEG15qnrqE1wsplAXXZogtcZzqZVexqS/zaUB6+p+vSVZ9KJEFRF7fGgzCkUJpvM0tLwdag==",
+            "version": "4.6.7",
+            "resolved": "https://registry.npmjs.org/greybel-intrinsics/-/greybel-intrinsics-4.6.7.tgz",
+            "integrity": "sha512-j0z9In1ff/kQSxv9RCF/sfeqxw9q6xUqZFn3GrKXJXhIn4zc8cA8Sa5PkPEXHbJRIzrtA1znig3NXLhYusrd7g==",
             "dependencies": {
-                "greyscript-interpreter": "~1.6.5",
+                "greyscript-interpreter": "~1.6.6",
                 "xregexp": "^5.1.1"
             }
         },
@@ -5216,11 +5216,11 @@
             }
         },
         "node_modules/greyscript-interpreter": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-1.6.5.tgz",
-            "integrity": "sha512-q53WaeF9KS3a3oKdBaPzJ2bJUh/6OoXFzqVK8eWWn6opYQqu6IexfSrriKF1VOmSSq0R3zboa7VOjFL51YwBNA==",
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-1.6.6.tgz",
+            "integrity": "sha512-ggyXTQibG8jI/I96nVyytVpFk/Ib5VTxqwnIDKFtTvqNZoysQXzhYQPHzCAJwdKEOoXwz59JRTNpGPTRKmIr5A==",
             "dependencies": {
-                "greybel-interpreter": "~4.5.12",
+                "greybel-interpreter": "~4.5.13",
                 "greyscript-core": "~1.5.13"
             }
         },
@@ -11927,19 +11927,19 @@
             }
         },
         "greybel-gh-mock-intrinsics": {
-            "version": "4.7.7",
-            "resolved": "https://registry.npmjs.org/greybel-gh-mock-intrinsics/-/greybel-gh-mock-intrinsics-4.7.7.tgz",
-            "integrity": "sha512-7zYNTPo/8D7yYQtjeuu9fv9JTxnb/zagRxi75cxg1TOuInsOzRLepiCmqGPIUhPPhlJnKYUkD31+rTtuesrCDg==",
+            "version": "4.7.8",
+            "resolved": "https://registry.npmjs.org/greybel-gh-mock-intrinsics/-/greybel-gh-mock-intrinsics-4.7.8.tgz",
+            "integrity": "sha512-lktsvhpEjKk/qaRLcCq1TYJ/gYg6hQ2GsuPhSK0PCaKlBP6oBEQqZZRhdKGhuEXYEgmUAGKY42wZ0FEdJRVI/w==",
             "requires": {
                 "blueimp-md5": "^2.19.0",
                 "greybel-mock-environment": "~2.4.15",
-                "greyscript-interpreter": "~1.6.5"
+                "greyscript-interpreter": "~1.6.6"
             }
         },
         "greybel-interpreter": {
-            "version": "4.5.12",
-            "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-4.5.12.tgz",
-            "integrity": "sha512-NAuuua89CijSzAgHDTKn3FL+jGjjD4pKWSONHLA4Vp/ZW4lhXAnzIIn6rP3ucO5yBV+nZlpuxNf3PXi75tRj6g==",
+            "version": "4.5.13",
+            "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-4.5.13.tgz",
+            "integrity": "sha512-ky1sNM8YJ4e3v8hGRVB+Uz7NLzpy6Y/brVDbJeB8KDTPuTnb7MbEJhPXcNKGDU2zz2KwtBoKbaojPPaSKJ/ECQ==",
             "requires": {
                 "greybel-core": "~1.5.13",
                 "lru-cache": "^10.0.1"
@@ -11953,11 +11953,11 @@
             }
         },
         "greybel-intrinsics": {
-            "version": "4.6.6",
-            "resolved": "https://registry.npmjs.org/greybel-intrinsics/-/greybel-intrinsics-4.6.6.tgz",
-            "integrity": "sha512-PEO1xZ0OlCGNKiCvEG15qnrqE1wsplAXXZogtcZzqZVexqS/zaUB6+p+vSVZ9KJEFRF7fGgzCkUJpvM0tLwdag==",
+            "version": "4.6.7",
+            "resolved": "https://registry.npmjs.org/greybel-intrinsics/-/greybel-intrinsics-4.6.7.tgz",
+            "integrity": "sha512-j0z9In1ff/kQSxv9RCF/sfeqxw9q6xUqZFn3GrKXJXhIn4zc8cA8Sa5PkPEXHbJRIzrtA1znig3NXLhYusrd7g==",
             "requires": {
-                "greyscript-interpreter": "~1.6.5",
+                "greyscript-interpreter": "~1.6.6",
                 "xregexp": "^5.1.1"
             }
         },
@@ -11991,11 +11991,11 @@
             }
         },
         "greyscript-interpreter": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-1.6.5.tgz",
-            "integrity": "sha512-q53WaeF9KS3a3oKdBaPzJ2bJUh/6OoXFzqVK8eWWn6opYQqu6IexfSrriKF1VOmSSq0R3zboa7VOjFL51YwBNA==",
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-1.6.6.tgz",
+            "integrity": "sha512-ggyXTQibG8jI/I96nVyytVpFk/Ib5VTxqwnIDKFtTvqNZoysQXzhYQPHzCAJwdKEOoXwz59JRTNpGPTRKmIr5A==",
             "requires": {
-                "greybel-interpreter": "~4.5.12",
+                "greybel-interpreter": "~4.5.13",
                 "greyscript-core": "~1.5.13"
             }
         },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "email": "soerenwehmeier@googlemail.com"
     },
     "icon": "icon.png",
-    "version": "2.2.21",
+    "version": "2.2.22",
     "repository": {
         "type": "git",
         "url": "git@github.com:ayecue/greybel-vs.git"
@@ -567,10 +567,10 @@
         "comment-parser": "^1.4.1",
         "css-color-names": "^1.0.1",
         "greybel-agent": "~1.7.0",
-        "greybel-gh-mock-intrinsics": "~4.7.7",
-        "greybel-intrinsics": "~4.6.6",
+        "greybel-gh-mock-intrinsics": "~4.7.8",
+        "greybel-intrinsics": "~4.6.7",
         "greyscript-core": "~1.5.13",
-        "greyscript-interpreter": "~1.6.5",
+        "greyscript-interpreter": "~1.6.6",
         "greyscript-meta": "~2.4.1",
         "greyscript-textmate": "~1.8.0",
         "greyscript-transpiler": "~0.6.12",

--- a/package.json
+++ b/package.json
@@ -112,27 +112,26 @@
                 },
                 {
                     "command": "greybel.build",
-                    "when": "resourceLangId == greyscript && !isWeb",
+                    "when": "resourceLangId == greyscript",
                     "group": "1_modification"
                 },
                 {
                     "command": "greybel.api",
-                    "when": "resourceLangId == greyscript && !isWeb",
+                    "when": "resourceLangId == greyscript",
                     "group": "z_commands"
                 },
                 {
                     "command": "greybel.preview",
-                    "when": "resourceLangId == greyscript && !isWeb",
+                    "when": "resourceLangId == greyscript",
                     "group": "z_commands"
                 },
                 {
                     "command": "greybel.share",
-                    "when": "resourceLangId == greyscript && !isWeb",
+                    "when": "resourceLangId == greyscript",
                     "group": "z_commands"
                 },
                 {
                     "command": "greybel.import",
-                    "when": "!isWeb",
                     "group": "1_modification"
                 }
             ],
@@ -157,17 +156,16 @@
             "explorer/context": [
                 {
                     "command": "greybel.build",
-                    "when": "resourceLangId == greyscript && !isWeb",
+                    "when": "resourceLangId == greyscript",
                     "group": "1_modification"
                 },
                 {
                     "command": "greybel.share",
-                    "when": "resourceLangId == greyscript && !isWeb",
+                    "when": "resourceLangId == greyscript",
                     "group": "1_modification"
                 },
                 {
                     "command": "greybel.import",
-                    "when": "!isWeb",
                     "group": "1_modification"
                 }
             ],
@@ -210,11 +208,11 @@
                 },
                 {
                     "command": "greybel.build",
-                    "when": "resourceLangId == greyscript && !isWeb"
+                    "when": "resourceLangId == greyscript"
                 },
                 {
                     "command": "greybel.import",
-                    "when": "resourceLangId == greyscript && !isWeb"
+                    "when": "resourceLangId == greyscript"
                 },
                 {
                     "command": "greybel.gotoError",
@@ -230,7 +228,7 @@
                 },
                 {
                     "command": "greybel.clearSecrets",
-                    "when": "resourceLangId == greyscript && !isWeb"
+                    "when": "resourceLangId == greyscript"
                 }
             ]
         },
@@ -279,8 +277,7 @@
             },
             {
                 "command": "greybel.build",
-                "title": "Greybel: Build",
-                "when": "!isWeb"
+                "title": "Greybel: Build"
             },
             {
                 "command": "greybel.transform.clipboard",
@@ -304,13 +301,11 @@
             },
             {
                 "command": "greybel.api",
-                "title": "Greybel: API Documentation",
-                "when": "!isWeb"
+                "title": "Greybel: API Documentation"
             },
             {
                 "command": "greybel.preview",
-                "title": "Greybel: Preview output",
-                "when": "!isWeb"
+                "title": "Greybel: Preview output"
             },
             {
                 "command": "greybel.refresh",
@@ -441,34 +436,29 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Generate installer when building.",
-                    "when": "!isWeb",
                     "scope": "resource"
                 },
                 "greybel.transpiler.installer.maxChars": {
                     "type": "number",
                     "default": 155000,
                     "minimum": 1000,
-                    "description": "Amount of characters allowed in one file before splitting when creating installer.",
-                    "when": "!isWeb"
+                    "description": "Amount of characters allowed in one file before splitting when creating installer."
                 },
                 "greybel.transpiler.installer.autoCompile": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Enable auto compile feature for installer.",
-                    "when": "!isWeb"
+                    "description": "Enable auto compile feature for installer."
                 },
                 "greybel.createIngame.active": {
                     "type": "boolean",
                     "default": false,
                     "description": "Create files automatically in-game.",
-                    "when": "!isWeb",
                     "scope": "resource"
                 },
                 "greybel.createIngame.autoCompile": {
                     "type": "boolean",
                     "default": false,
                     "description": "Build root file automatically.",
-                    "when": "!isWeb",
                     "scope": "resource"
                 },
                 "greybel.createIngame.agent": {
@@ -479,7 +469,6 @@
                     ],
                     "default": "headless",
                     "description": "Agent used for file import.",
-                    "when": "!isWeb",
                     "scope": "resource"
                 },
                 "greybel.createIngame.mode": {
@@ -490,7 +479,6 @@
                     ],
                     "default": "local",
                     "description": "Creation mode.",
-                    "when": "!isWeb",
                     "scope": "resource"
                 },
                 "greybel.createIngame.steamUser": {
@@ -499,8 +487,7 @@
                         "null"
                     ],
                     "default": null,
-                    "description": "Steam user.",
-                    "when": "!isWeb"
+                    "description": "Steam user."
                 }
             }
         },

--- a/src/debug/session.ts
+++ b/src/debug/session.ts
@@ -29,10 +29,11 @@ import { init as initIntrinsics } from 'greybel-intrinsics';
 import { Interpreter } from 'greyscript-interpreter';
 import vscode, { Uri } from 'vscode';
 
+import { PseudoFS } from '../helper/fs';
 import { showCustomErrorMessage } from '../helper/show-custom-error';
 import { ansiProvider, useColor } from '../helper/text-mesh-transform';
 import { getPreviewInstance } from '../preview';
-import { InterpreterResourceProvider, PseudoFS } from '../resource';
+import { InterpreterResourceProvider } from '../resource';
 import { GrebyelDebugger, GrebyelPseudoDebugger } from './debugger';
 import { VSOutputHandler } from './output';
 import { DebugSessionLike } from './types';

--- a/src/helper/create-base-path.ts
+++ b/src/helper/create-base-path.ts
@@ -1,6 +1,6 @@
 import { Uri } from 'vscode';
 
-import { PseudoFS } from '../resource';
+import { PseudoFS } from './fs';
 
 export const createBasePath = (
   target: string,

--- a/src/helper/document-manager.ts
+++ b/src/helper/document-manager.ts
@@ -4,6 +4,7 @@ import LRU from 'lru-cache';
 import { ASTBase } from 'miniscript-core';
 import vscode, { TextDocument, Uri } from 'vscode';
 
+import { tryToGetPath } from './fs';
 import typeManager from './type-manager';
 
 export interface ParseResultOptions {
@@ -219,7 +220,8 @@ export class DocumentParseQueue extends EventEmitter {
 
   async open(target: string): Promise<ParseResult | null> {
     try {
-      const textDocument = await vscode.workspace.openTextDocument(target);
+      const actualPath = await tryToGetPath(target, `${target}.src`);
+      const textDocument = await vscode.workspace.openTextDocument(actualPath);
       return this.get(textDocument);
     } catch (err) {
       return null;

--- a/src/helper/fs.ts
+++ b/src/helper/fs.ts
@@ -1,0 +1,55 @@
+import path from 'path';
+// @ts-ignore: No type definitions
+import { TextDecoderLite as TextDecoder } from 'text-encoder-lite';
+import vscode, { Uri } from 'vscode';
+
+const fs = vscode.workspace.fs;
+
+export class PseudoFS {
+  static sep: string = path.sep;
+  static win32 = path.win32;
+  static posix = path.posix;
+
+  static basename(file: string): string {
+    return path.basename(file);
+  }
+
+  static dirname(file: string): string {
+    return path.dirname(file);
+  }
+
+  static resolve(file: string): string {
+    return path.resolve(file);
+  }
+
+  static isWindows() {
+    return this.win32.sep === this.sep;
+  }
+}
+
+export async function tryToGet(targetUri: string): Promise<Uint8Array | null> {
+  try {
+    return await fs.readFile(Uri.file(targetUri));
+  } catch (err) {
+    console.error(err);
+  }
+
+  return null;
+}
+
+export async function tryToGetPath(
+  targetUri: string,
+  altTargetUri: string
+): Promise<string> {
+  if (await tryToGet(targetUri)) {
+    return targetUri;
+  } else if (await tryToGet(altTargetUri)) {
+    return altTargetUri;
+  }
+  return targetUri;
+}
+
+export async function tryToDecode(targetUri: string): Promise<string> {
+  const out = await tryToGet(targetUri);
+  return out ? new TextDecoder().decode(out) : '';
+}

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -15,8 +15,8 @@ import vscode, {
 
 import { LookupHelper } from './helper/lookup-type';
 import { TypeInfoWithDefinition } from './helper/type-manager';
-import { PseudoFS } from './resource';
 import { createHover } from './helper/tooltip';
+import { PseudoFS, tryToGetPath } from './helper/fs';
 
 function formatType(type: string): string {
   const segments = type.split(':');
@@ -74,7 +74,8 @@ export function activate(_context: ExtensionContext) {
         const fileDir = importCodeAst.path;
 
         const rootDir = fileDir.startsWith('/') ? vscode.workspace.workspaceFolders[0]?.uri : Uri.joinPath(Uri.file(document.fileName), '..');
-        const target = Uri.joinPath(rootDir, fileDir);
+        const result = Uri.joinPath(rootDir, fileDir).fsPath;
+        const target = Uri.file(await tryToGetPath(result, `${result}.src`));
 
         const output = [
           `[Inserts file "${PseudoFS.basename(

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -3,58 +3,8 @@ import {
   ResourceHandler as TranspilerResourceHandler,
   ResourceProvider as TranspilerResourceProviderBase
 } from 'greybel-transpiler';
-import path from 'path';
-// @ts-ignore: No type definitions
-import { TextDecoderLite as TextDecoder } from 'text-encoder-lite';
 import vscode, { Uri } from 'vscode';
-
-const fs = vscode.workspace.fs;
-
-export class PseudoFS {
-  static sep: string = path.sep;
-  static win32 = path.win32;
-  static posix = path.posix;
-
-  static basename(file: string): string {
-    return path.basename(file);
-  }
-
-  static dirname(file: string): string {
-    return path.dirname(file);
-  }
-
-  static resolve(file: string): string {
-    return path.resolve(file);
-  }
-
-  static isWindows() {
-    return this.win32.sep === this.sep;
-  }
-}
-
-async function tryToGet(targetUri: string): Promise<Uint8Array | null> {
-  try {
-    return await fs.readFile(Uri.file(targetUri));
-  } catch (err) {
-    console.error(err);
-  }
-
-  return null;
-}
-
-async function tryToGetPath(targetUri: string, altTargetUri: string): Promise<string> {
-  if (await tryToGet(targetUri)) {
-    return targetUri;
-  } else if (await tryToGet(altTargetUri)) {
-    return altTargetUri;
-  }
-  return targetUri;
-}
-
-async function tryToDecode(targetUri: string): Promise<string> {
-  const out = await tryToGet(targetUri);
-  return out ? new TextDecoder().decode(out) : '';
-}
+import { tryToDecode, tryToGet, tryToGetPath } from './helper/fs';
 
 export class TranspilerResourceProvider extends TranspilerResourceProviderBase {
   getHandler(): TranspilerResourceHandler {


### PR DESCRIPTION
Includes:
- ignore return statement when it's not within function scope
- remove any limitations from the vscode web version since everything seems to be compatible with code serve-web
- fix hover import and includes with missing extension
- fix document-manager for includes and imports without file extension