### PR TITLE
2.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1123,3 +1123,10 @@ All notable changes to this project will be documented in this file.
 ## [2.3.10] - 26.06.2024
 
 - minor optimizations regarding type resolver such as resolving types through parentheses, keeping api definitions apart from custom definitions preventing unwanted merged definitions, using a proxy container for signature definitions and fixing line overriding for identifier causing to use wrong start lines
+
+## [2.3.11] - 01.07.2024
+
+- add super keyword to type-analyzer
+- fix member expression containing new unary when resolving type
+- only use shallow copy when copying entity to avoid memory exhaustion for type-analyzer
+- properly resolve members of scope variables and api definitions for type-analyzer

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "greyscript-textmate": "~1.8.1",
         "greyscript-transpiler": "~0.8.3",
         "lru-cache": "^7.14.1",
-        "miniscript-type-analyzer": "~0.4.4",
+        "miniscript-type-analyzer": "~0.4.5",
         "node-json-stream": "~0.2.6",
         "text-encoder-lite": "^2.0.0",
         "text-mesh-transformer": "^1.4.1"
@@ -6222,9 +6222,9 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "node_modules/miniscript-type-analyzer": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.4.tgz",
-      "integrity": "sha512-ifZcyyC5m0jyT/uKETQ75VN1RNZdm5Pd1grn0s1AIG+tY2fu78sz5HHBflhMQNRmw0N3J89A80XF1PuL0hTz9Q==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.5.tgz",
+      "integrity": "sha512-HR8SNvHkGPY/U/sCCy9JSBRBfoq5v44eQtxJbQHry1rMYdanfYOEuUaP4yLLtwylG8jHh2p7COBe7u/SSYHvtw==",
       "dependencies": {
         "comment-parser": "^1.4.1",
         "meta-utils": "~2.4.6",
@@ -12738,9 +12738,9 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "miniscript-type-analyzer": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.4.tgz",
-      "integrity": "sha512-ifZcyyC5m0jyT/uKETQ75VN1RNZdm5Pd1grn0s1AIG+tY2fu78sz5HHBflhMQNRmw0N3J89A80XF1PuL0hTz9Q==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.5.tgz",
+      "integrity": "sha512-HR8SNvHkGPY/U/sCCy9JSBRBfoq5v44eQtxJbQHry1rMYdanfYOEuUaP4yLLtwylG8jHh2p7COBe7u/SSYHvtw==",
       "requires": {
         "comment-parser": "^1.4.1",
         "meta-utils": "~2.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "greyscript-textmate": "~1.8.1",
         "greyscript-transpiler": "~0.8.3",
         "lru-cache": "^7.14.1",
-        "miniscript-type-analyzer": "~0.4.2",
+        "miniscript-type-analyzer": "~0.4.3",
         "node-json-stream": "~0.2.6",
         "text-encoder-lite": "^2.0.0",
         "text-mesh-transformer": "^1.4.1"
@@ -6222,9 +6222,9 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "node_modules/miniscript-type-analyzer": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.2.tgz",
-      "integrity": "sha512-/Zezc6+mOhSeHTspi+weVuLZ4bvKVNIo5YgsPughQIpS+QuKzWr7RqULrEYgL241XiGsJc80IqifWuyOjtkvMw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.3.tgz",
+      "integrity": "sha512-JFMGTFig49IULHkELy5hRXCiDxExvdMCQBR6LkTyjTFXeC1/gQ3M49DOq2pqjOzH/LZnPUAp8Ps+hftVrrv1Tg==",
       "dependencies": {
         "comment-parser": "^1.4.1",
         "meta-utils": "~2.4.6",
@@ -12738,9 +12738,9 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "miniscript-type-analyzer": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.2.tgz",
-      "integrity": "sha512-/Zezc6+mOhSeHTspi+weVuLZ4bvKVNIo5YgsPughQIpS+QuKzWr7RqULrEYgL241XiGsJc80IqifWuyOjtkvMw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.3.tgz",
+      "integrity": "sha512-JFMGTFig49IULHkELy5hRXCiDxExvdMCQBR6LkTyjTFXeC1/gQ3M49DOq2pqjOzH/LZnPUAp8Ps+hftVrrv1Tg==",
       "requires": {
         "comment-parser": "^1.4.1",
         "meta-utils": "~2.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-vs",
-  "version": "2.3.10",
+  "version": "2.3.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-vs",
-      "version": "2.3.10",
+      "version": "2.3.11",
       "dependencies": {
         "@vscode/debugadapter": "^1.51.1",
         "@vscode/debugprotocol": "^1.51.0",
@@ -25,7 +25,7 @@
         "greyscript-textmate": "~1.8.1",
         "greyscript-transpiler": "~0.8.3",
         "lru-cache": "^7.14.1",
-        "miniscript-type-analyzer": "~0.3.10",
+        "miniscript-type-analyzer": "~0.4.2",
         "node-json-stream": "~0.2.6",
         "text-encoder-lite": "^2.0.0",
         "text-mesh-transformer": "^1.4.1"
@@ -6222,9 +6222,9 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "node_modules/miniscript-type-analyzer": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.3.10.tgz",
-      "integrity": "sha512-uP08qfCxmRfAjP2l9DQIMq9teeWdLkmCWhshT7drxhUpQX0tuks9UcE/VgTJ5mdUCpmOCgbvdQlncyPaw+0jIQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.2.tgz",
+      "integrity": "sha512-/Zezc6+mOhSeHTspi+weVuLZ4bvKVNIo5YgsPughQIpS+QuKzWr7RqULrEYgL241XiGsJc80IqifWuyOjtkvMw==",
       "dependencies": {
         "comment-parser": "^1.4.1",
         "meta-utils": "~2.4.6",
@@ -12738,9 +12738,9 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "miniscript-type-analyzer": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.3.10.tgz",
-      "integrity": "sha512-uP08qfCxmRfAjP2l9DQIMq9teeWdLkmCWhshT7drxhUpQX0tuks9UcE/VgTJ5mdUCpmOCgbvdQlncyPaw+0jIQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.2.tgz",
+      "integrity": "sha512-/Zezc6+mOhSeHTspi+weVuLZ4bvKVNIo5YgsPughQIpS+QuKzWr7RqULrEYgL241XiGsJc80IqifWuyOjtkvMw==",
       "requires": {
         "comment-parser": "^1.4.1",
         "meta-utils": "~2.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "greyscript-textmate": "~1.8.1",
         "greyscript-transpiler": "~0.8.3",
         "lru-cache": "^7.14.1",
-        "miniscript-type-analyzer": "~0.4.3",
+        "miniscript-type-analyzer": "~0.4.4",
         "node-json-stream": "~0.2.6",
         "text-encoder-lite": "^2.0.0",
         "text-mesh-transformer": "^1.4.1"
@@ -6222,9 +6222,9 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "node_modules/miniscript-type-analyzer": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.3.tgz",
-      "integrity": "sha512-JFMGTFig49IULHkELy5hRXCiDxExvdMCQBR6LkTyjTFXeC1/gQ3M49DOq2pqjOzH/LZnPUAp8Ps+hftVrrv1Tg==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.4.tgz",
+      "integrity": "sha512-ifZcyyC5m0jyT/uKETQ75VN1RNZdm5Pd1grn0s1AIG+tY2fu78sz5HHBflhMQNRmw0N3J89A80XF1PuL0hTz9Q==",
       "dependencies": {
         "comment-parser": "^1.4.1",
         "meta-utils": "~2.4.6",
@@ -12738,9 +12738,9 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "miniscript-type-analyzer": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.3.tgz",
-      "integrity": "sha512-JFMGTFig49IULHkELy5hRXCiDxExvdMCQBR6LkTyjTFXeC1/gQ3M49DOq2pqjOzH/LZnPUAp8Ps+hftVrrv1Tg==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.4.4.tgz",
+      "integrity": "sha512-ifZcyyC5m0jyT/uKETQ75VN1RNZdm5Pd1grn0s1AIG+tY2fu78sz5HHBflhMQNRmw0N3J89A80XF1PuL0hTz9Q==",
       "requires": {
         "comment-parser": "^1.4.1",
         "meta-utils": "~2.4.6",

--- a/package.json
+++ b/package.json
@@ -585,7 +585,7 @@
     "greyscript-meta-web": "~1.0.2",
     "greyscript-textmate": "~1.8.1",
     "greyscript-transpiler": "~0.8.3",
-    "miniscript-type-analyzer": "~0.4.4",
+    "miniscript-type-analyzer": "~0.4.5",
     "lru-cache": "^7.14.1",
     "node-json-stream": "~0.2.6",
     "text-encoder-lite": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -585,7 +585,7 @@
     "greyscript-meta-web": "~1.0.2",
     "greyscript-textmate": "~1.8.1",
     "greyscript-transpiler": "~0.8.3",
-    "miniscript-type-analyzer": "~0.4.3",
+    "miniscript-type-analyzer": "~0.4.4",
     "lru-cache": "^7.14.1",
     "node-json-stream": "~0.2.6",
     "text-encoder-lite": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "soerenwehmeier@googlemail.com"
   },
   "icon": "icon.png",
-  "version": "2.3.10",
+  "version": "2.3.11",
   "repository": {
     "type": "git",
     "url": "git@github.com:ayecue/greybel-vs.git"
@@ -585,7 +585,7 @@
     "greyscript-meta-web": "~1.0.2",
     "greyscript-textmate": "~1.8.1",
     "greyscript-transpiler": "~0.8.3",
-    "miniscript-type-analyzer": "~0.3.10",
+    "miniscript-type-analyzer": "~0.4.2",
     "lru-cache": "^7.14.1",
     "node-json-stream": "~0.2.6",
     "text-encoder-lite": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -585,7 +585,7 @@
     "greyscript-meta-web": "~1.0.2",
     "greyscript-textmate": "~1.8.1",
     "greyscript-transpiler": "~0.8.3",
-    "miniscript-type-analyzer": "~0.4.2",
+    "miniscript-type-analyzer": "~0.4.3",
     "lru-cache": "^7.14.1",
     "node-json-stream": "~0.2.6",
     "text-encoder-lite": "^2.0.0",

--- a/src/autocomplete/constants.ts
+++ b/src/autocomplete/constants.ts
@@ -5,14 +5,8 @@ export const AVAILABLE_CONSTANTS: CompletionItem[] = [
   'true',
   'false',
   'null',
-  'map',
-  'funcRef',
-  'list',
-  'number',
-  'string',
   'params',
   'globals',
   'locals',
-  'outer',
-  'self'
+  'outer'
 ].map((item: string) => new CompletionItem(item, CompletionItemKind.Constant));

--- a/src/helper/lookup-type.ts
+++ b/src/helper/lookup-type.ts
@@ -10,7 +10,8 @@ import {
 import {
   CompletionItem,
   Document as TypeDocument,
-  IEntity
+  IEntity,
+  CompletionItemKind
 } from 'miniscript-type-analyzer';
 import { Position, TextDocument } from 'vscode';
 
@@ -113,6 +114,21 @@ export class LookupHelper {
     const typeDoc = typeManager.get(this.document.uri.fsPath);
     const result: Map<string, CompletionItem> = new Map();
     const scopeContext = typeDoc.getScopeContext(item.scope);
+
+    if (scopeContext.scope.isSelfAvailable()) {
+      result.set('self', {
+        kind: CompletionItemKind.Constant,
+        line: -1
+      });
+    }
+
+    if (scopeContext.scope.isSuperAvailable()) {
+      result.set('super', {
+        kind: CompletionItemKind.Constant,
+        line: -1
+      });
+    }
+
     const assignments = Array.from(
       scopeContext.scope.locals.getAllIdentifier().entries()
     )

--- a/src/helper/lookup-type.ts
+++ b/src/helper/lookup-type.ts
@@ -150,6 +150,10 @@ export class LookupHelper {
       }
     }
 
+    for (const assignment of typeDoc.api.getAllIdentifier()) {
+      result.set(...assignment);
+    }
+
     return result;
   }
 


### PR DESCRIPTION
Includes:
- add super keyword to type-analyzer
- fix member expression containing new unary when resolving type
- only use shallow copy when copying entity to avoid memory exhaustion for type-analyzer
- properly resolve members of scope variables and api definitions for type-analyzer