### PR TITLE
2.3.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1153,3 +1153,5 @@ All notable changes to this project will be documented in this file.
 ## [2.3.15] - 17.07.2024
 
 - enforce LF in import functionality just as in the build feature - related to [#222](https://github.com/ayecue/greybel-vs/issues/222)
+- let type-analyzer resolve logical expressions as number
+- let type-analyzer set proper label for binary expression

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1152,6 +1152,6 @@ All notable changes to this project will be documented in this file.
 
 ## [2.3.15] - 17.07.2024
 
-- enforce LF in import functionality just as in the build feature - related to [#222](https://github.com/ayecue/greybel-vs/issues/222)
+- enforce LF in import functionality just as in the build feature - related to [#222](https://github.com/ayecue/greybel-vs/issues/222) - thanks for reporting to Ren 
 - let type-analyzer resolve logical expressions as number
 - let type-analyzer set proper label for binary expression

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1149,3 +1149,7 @@ All notable changes to this project will be documented in this file.
 
 - properly check in type-analyzer if string in index is valid identifier
 - let type-analyzer resolve isa expressions as number
+
+## [2.3.15] - 17.07.2024
+
+- enforce LF in import functionality just as in the build feature - related to [#222](https://github.com/ayecue/greybel-vs/issues/222)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-vs",
-  "version": "2.3.14",
+  "version": "2.3.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-vs",
-      "version": "2.3.14",
+      "version": "2.3.15",
       "dependencies": {
         "@vscode/debugadapter": "^1.51.1",
         "@vscode/debugprotocol": "^1.51.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "greyscript-textmate": "~1.8.1",
         "greyscript-transpiler": "~0.8.3",
         "lru-cache": "^7.14.1",
-        "miniscript-type-analyzer": "~0.5.3",
+        "miniscript-type-analyzer": "~0.5.4",
         "node-json-stream": "~0.2.6",
         "text-encoder-lite": "^2.0.0",
         "text-mesh-transformer": "^1.4.1"
@@ -6222,9 +6222,9 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "node_modules/miniscript-type-analyzer": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.5.3.tgz",
-      "integrity": "sha512-Vb09WjfypJqzxcSJo6pEXkjzgLfZAJxWpJvRC8s2rqv6BcJQh0AQWcPYJ9T3f3VgH24Qt1XtgrrM+OwaSPnQ4A==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.5.4.tgz",
+      "integrity": "sha512-gemAHDW2nXzBGFPx/i9uGDzQsmO+iLU3gfnV9fGL8LPVmLnGIT+TqmlIoluWDsVPC2/93Pzqz6NHqKP1giy3ew==",
       "dependencies": {
         "comment-parser": "^1.4.1",
         "meta-utils": "~2.4.6",
@@ -12738,9 +12738,9 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "miniscript-type-analyzer": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.5.3.tgz",
-      "integrity": "sha512-Vb09WjfypJqzxcSJo6pEXkjzgLfZAJxWpJvRC8s2rqv6BcJQh0AQWcPYJ9T3f3VgH24Qt1XtgrrM+OwaSPnQ4A==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.5.4.tgz",
+      "integrity": "sha512-gemAHDW2nXzBGFPx/i9uGDzQsmO+iLU3gfnV9fGL8LPVmLnGIT+TqmlIoluWDsVPC2/93Pzqz6NHqKP1giy3ew==",
       "requires": {
         "comment-parser": "^1.4.1",
         "meta-utils": "~2.4.6",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "soerenwehmeier@googlemail.com"
   },
   "icon": "icon.png",
-  "version": "2.3.14",
+  "version": "2.3.15",
   "repository": {
     "type": "git",
     "url": "git@github.com:ayecue/greybel-vs.git"

--- a/package.json
+++ b/package.json
@@ -585,7 +585,7 @@
     "greyscript-meta-web": "~1.0.4",
     "greyscript-textmate": "~1.8.1",
     "greyscript-transpiler": "~0.8.3",
-    "miniscript-type-analyzer": "~0.5.3",
+    "miniscript-type-analyzer": "~0.5.4",
     "lru-cache": "^7.14.1",
     "node-json-stream": "~0.2.6",
     "text-encoder-lite": "^2.0.0",


### PR DESCRIPTION
Includes:
- enforce LF in import functionality just as in the build feature - related to [#222](https://github.com/ayecue/greybel-vs/issues/222)
- let type-analyzer resolve logical expressions as number
- let type-analyzer set proper label for binary expression