### PR TITLE
2.3.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1155,3 +1155,11 @@ All notable changes to this project will be documented in this file.
 - enforce LF in import functionality just as in the build feature - related to [#222](https://github.com/ayecue/greybel-vs/issues/222) - thanks for reporting to Ren 
 - let type-analyzer resolve logical expressions as number
 - let type-analyzer set proper label for binary expression
+
+## [2.3.16] - 18.07.2024
+
+- keep multiline comments in devMode when beautifying
+- fix beautify regarding multiline comments
+- fix beautify when having multiple commands in one line via semicolon
+- fix signature parser for multiline comments
+- add support for envar, file and line in type-analyzer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-vs",
-  "version": "2.3.15",
+  "version": "2.3.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-vs",
-      "version": "2.3.15",
+      "version": "2.3.16",
       "dependencies": {
         "@vscode/debugadapter": "^1.51.1",
         "@vscode/debugprotocol": "^1.51.0",
@@ -23,9 +23,9 @@
         "greyscript-meta": "~4.0.8",
         "greyscript-meta-web": "~1.0.4",
         "greyscript-textmate": "~1.8.1",
-        "greyscript-transpiler": "~0.8.3",
+        "greyscript-transpiler": "~0.9.0",
         "lru-cache": "^7.14.1",
-        "miniscript-type-analyzer": "~0.5.4",
+        "miniscript-type-analyzer": "~0.6.0",
         "node-json-stream": "~0.2.6",
         "text-encoder-lite": "^2.0.0",
         "text-mesh-transformer": "^1.4.1"
@@ -5149,9 +5149,9 @@
       }
     },
     "node_modules/greybel-transpiler": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-2.7.3.tgz",
-      "integrity": "sha512-IKnymonnuPQF4a74yQlQacl593gxsSjsP2RIB9SpkCwgaLnSoYgpF+0rpVIDleIlu3jNQUHEv1iOod7tNScp1w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-2.8.0.tgz",
+      "integrity": "sha512-ynhDu7g/9B9g90VQZqy9wVIaHtbQZSSdppMQL+CXF525h2PWjHR1k6zKrhwji6tzWY/fbHE7Azq+H8PGVq2yLw==",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
         "greybel-core": "~1.7.0"
@@ -5198,12 +5198,12 @@
       "integrity": "sha512-iUQ71FdcIn2ZaiarigyZiCu0quewx85ba+VAMuDNPDeXTIAaUirxWtE1dIDtZ8WFftSc5ijngJkQi14UsnA1JQ=="
     },
     "node_modules/greyscript-transpiler": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-0.8.3.tgz",
-      "integrity": "sha512-VS5fUTMbsKlIlMAQWBxxbMWlSF6XQkjwxpYdyOx2AWRXeyf+m2xOJ5i/BjxyBl7CwmpqEa6wplVzPtoPaqAQwA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-0.9.0.tgz",
+      "integrity": "sha512-qgLutkSohTcpUbttFr7El0FATsCew80T1ZrY8emD7eVvS9SVmoY8kzZhVSDmIq/g4ROxBbcMoQv7h3O6Al1Zzw==",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
-        "greybel-transpiler": "~2.7.3",
+        "greybel-transpiler": "~2.8.0",
         "greyscript-core": "~1.7.0"
       }
     },
@@ -6222,13 +6222,13 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "node_modules/miniscript-type-analyzer": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.5.4.tgz",
-      "integrity": "sha512-gemAHDW2nXzBGFPx/i9uGDzQsmO+iLU3gfnV9fGL8LPVmLnGIT+TqmlIoluWDsVPC2/93Pzqz6NHqKP1giy3ew==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.6.0.tgz",
+      "integrity": "sha512-nOC8y4YO2iBm7AeO5hxDoscFG3gXVPrHdcOwkf5ceGIYlArKEJPXtaQ6xuJ3aJqAvYbhjHsjLgsuPWBq4jS65w==",
       "dependencies": {
         "comment-parser": "^1.4.1",
+        "greybel-core": "~1.7.0",
         "meta-utils": "~2.4.6",
-        "miniscript-core": "^0.7.0",
         "object-code": "^1.3.3"
       }
     },
@@ -11926,9 +11926,9 @@
       }
     },
     "greybel-transpiler": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-2.7.3.tgz",
-      "integrity": "sha512-IKnymonnuPQF4a74yQlQacl593gxsSjsP2RIB9SpkCwgaLnSoYgpF+0rpVIDleIlu3jNQUHEv1iOod7tNScp1w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-2.8.0.tgz",
+      "integrity": "sha512-ynhDu7g/9B9g90VQZqy9wVIaHtbQZSSdppMQL+CXF525h2PWjHR1k6zKrhwji6tzWY/fbHE7Azq+H8PGVq2yLw==",
       "requires": {
         "blueimp-md5": "^2.19.0",
         "greybel-core": "~1.7.0"
@@ -11975,12 +11975,12 @@
       "integrity": "sha512-iUQ71FdcIn2ZaiarigyZiCu0quewx85ba+VAMuDNPDeXTIAaUirxWtE1dIDtZ8WFftSc5ijngJkQi14UsnA1JQ=="
     },
     "greyscript-transpiler": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-0.8.3.tgz",
-      "integrity": "sha512-VS5fUTMbsKlIlMAQWBxxbMWlSF6XQkjwxpYdyOx2AWRXeyf+m2xOJ5i/BjxyBl7CwmpqEa6wplVzPtoPaqAQwA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-0.9.0.tgz",
+      "integrity": "sha512-qgLutkSohTcpUbttFr7El0FATsCew80T1ZrY8emD7eVvS9SVmoY8kzZhVSDmIq/g4ROxBbcMoQv7h3O6Al1Zzw==",
       "requires": {
         "blueimp-md5": "^2.19.0",
-        "greybel-transpiler": "~2.7.3",
+        "greybel-transpiler": "~2.8.0",
         "greyscript-core": "~1.7.0"
       }
     },
@@ -12738,13 +12738,13 @@
       "integrity": "sha512-iqDK2J6yO0tYViQ8gjcZIFrlhk1yVkP44BnMPotzk0EZc5kqPjrqks03CC9DDWpJ0NpZ5R9o/gVglNDRS5ibYw=="
     },
     "miniscript-type-analyzer": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.5.4.tgz",
-      "integrity": "sha512-gemAHDW2nXzBGFPx/i9uGDzQsmO+iLU3gfnV9fGL8LPVmLnGIT+TqmlIoluWDsVPC2/93Pzqz6NHqKP1giy3ew==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.6.0.tgz",
+      "integrity": "sha512-nOC8y4YO2iBm7AeO5hxDoscFG3gXVPrHdcOwkf5ceGIYlArKEJPXtaQ6xuJ3aJqAvYbhjHsjLgsuPWBq4jS65w==",
       "requires": {
         "comment-parser": "^1.4.1",
+        "greybel-core": "~1.7.0",
         "meta-utils": "~2.4.6",
-        "miniscript-core": "^0.7.0",
         "object-code": "^1.3.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "soerenwehmeier@googlemail.com"
   },
   "icon": "icon.png",
-  "version": "2.3.15",
+  "version": "2.3.16",
   "repository": {
     "type": "git",
     "url": "git@github.com:ayecue/greybel-vs.git"
@@ -584,8 +584,8 @@
     "greyscript-meta": "~4.0.8",
     "greyscript-meta-web": "~1.0.4",
     "greyscript-textmate": "~1.8.1",
-    "greyscript-transpiler": "~0.8.3",
-    "miniscript-type-analyzer": "~0.5.4",
+    "greyscript-transpiler": "~0.9.0",
+    "miniscript-type-analyzer": "~0.6.0",
     "lru-cache": "^7.14.1",
     "node-json-stream": "~0.2.6",
     "text-encoder-lite": "^2.0.0",


### PR DESCRIPTION
Includes:
- keep multiline comments in devMode when beautifying
- fix beautify regarding multiline comments
- fix beautify when having multiple commands in one line via semicolon
- fix signature parser for multiline comments
- add support for envar, file and line in type-analyzer