### PR TITLE
2.4.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1256,4 +1256,4 @@ All notable changes to this project will be documented in this file.
 
 ## [2.4.13] - 20.08.2024
 
-- fix handling textDocument/documentSymbol failed error, which was caused when there was invalid syntax at some point - related to [#243](https://github.com/ayecue/greybel-vs/issues/243) - thanks for reporting to [@linuxgruven](https://github.com/linuxgruven)
+- fix handling textDocument/documentSymbol failed error in ls, which was caused when there was invalid syntax at some point - related to [#243](https://github.com/ayecue/greybel-vs/issues/243) - thanks for reporting to [@linuxgruven](https://github.com/linuxgruven)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1253,3 +1253,7 @@ All notable changes to this project will be documented in this file.
 ## [2.4.12] - 19.08.2024
 
 - properly handle missing files in ls - related to [#243](https://github.com/ayecue/greybel-vs/issues/243) - thanks for reporting to [@linuxgruven](https://github.com/linuxgruven)
+
+## [2.4.13] - 20.08.2024
+
+- fix handling textDocument/documentSymbol failed error, which was caused when there was invalid syntax at some point - related to [#243](https://github.com/ayecue/greybel-vs/issues/243) - thanks for reporting to [@linuxgruven](https://github.com/linuxgruven)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-vs",
-  "version": "2.4.12",
+  "version": "2.4.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-vs",
-      "version": "2.4.12",
+      "version": "2.4.13",
       "dependencies": {
         "@vscode/debugadapter": "^1.51.1",
         "@vscode/debugprotocol": "^1.51.0",
@@ -18,8 +18,8 @@
         "greybel-agent": "~1.8.1",
         "greybel-gh-mock-intrinsics": "~5.0.5",
         "greybel-intrinsics": "~5.0.5",
-        "greybel-languageserver": "~1.4.3",
-        "greybel-languageserver-browser": "~1.0.3",
+        "greybel-languageserver": "~1.4.4",
+        "greybel-languageserver-browser": "~1.0.4",
         "greyscript-core": "~2.0.3",
         "greyscript-interpreter": "~2.0.5",
         "greyscript-meta": "~4.0.10",
@@ -3756,12 +3756,12 @@
       }
     },
     "node_modules/greybel-languageserver": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/greybel-languageserver/-/greybel-languageserver-1.4.3.tgz",
-      "integrity": "sha512-643151k7VTjWwxDoPuzD790oGIeD7p+K0tWo2HSKhjVieFpC4xymYDh2zIf5SV6sMRg1v6+k6J15saX5YGIkFQ==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/greybel-languageserver/-/greybel-languageserver-1.4.4.tgz",
+      "integrity": "sha512-huPp36eAg6VQHRtQ/8/TJK0zXQzWsf8bSua4azLyqHbQjLNrCFChuSkJf/D7kIV8Ub0HaoCHBmDZg0V7mUyf2Q==",
       "license": "ISC",
       "dependencies": {
-        "greybel-languageserver-core": "^1.0.3",
+        "greybel-languageserver-core": "^1.0.4",
         "greyscript-core": "~2.0.3",
         "greyscript-meta": "~4.0.10",
         "greyscript-transpiler": "~1.0.9",
@@ -3775,12 +3775,12 @@
       }
     },
     "node_modules/greybel-languageserver-browser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/greybel-languageserver-browser/-/greybel-languageserver-browser-1.0.3.tgz",
-      "integrity": "sha512-a5b0jBTLg2Yi5/YkXBoKgBQJphmJDwlWgfv7p0eCY4i/2jZbxIyPnRRoSnNiIjySXh7Vkglc2SOBflymbvCXeA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/greybel-languageserver-browser/-/greybel-languageserver-browser-1.0.4.tgz",
+      "integrity": "sha512-MshHfaAU2EgfguvhTIVddJYcAEz5BQ4EPulktZHdJQ3QESL6NhA34v0yV15JWy+ZqSF4+QCMPPbgXXF7JWjKtQ==",
       "license": "ISC",
       "dependencies": {
-        "greybel-languageserver-core": "^1.0.3",
+        "greybel-languageserver-core": "^1.0.4",
         "greyscript-core": "~2.0.3",
         "greyscript-meta": "~4.0.10",
         "greyscript-transpiler": "~1.0.9",
@@ -3791,9 +3791,9 @@
       }
     },
     "node_modules/greybel-languageserver-core": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/greybel-languageserver-core/-/greybel-languageserver-core-1.0.3.tgz",
-      "integrity": "sha512-g8gPCKD9/nRKZ3Y/GE19Y88KImnO0IwvDuPQ0cKz8ixwU4Mf4FifEasSB/BumchZUFdWgQ9dkXW7fcjYlmM4RA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/greybel-languageserver-core/-/greybel-languageserver-core-1.0.4.tgz",
+      "integrity": "sha512-4gVXl87Yhqfl4MggAnzeSpE7vskMu9Dj7ArnzCY68SoJRd/LhRMAUHYM7uA1I8kRhP0BAHBtMVVkKM2fAP+CVg==",
       "license": "ISC",
       "dependencies": {
         "color-convert": "^2.0.1",
@@ -10204,11 +10204,11 @@
       }
     },
     "greybel-languageserver": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/greybel-languageserver/-/greybel-languageserver-1.4.3.tgz",
-      "integrity": "sha512-643151k7VTjWwxDoPuzD790oGIeD7p+K0tWo2HSKhjVieFpC4xymYDh2zIf5SV6sMRg1v6+k6J15saX5YGIkFQ==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/greybel-languageserver/-/greybel-languageserver-1.4.4.tgz",
+      "integrity": "sha512-huPp36eAg6VQHRtQ/8/TJK0zXQzWsf8bSua4azLyqHbQjLNrCFChuSkJf/D7kIV8Ub0HaoCHBmDZg0V7mUyf2Q==",
       "requires": {
-        "greybel-languageserver-core": "^1.0.3",
+        "greybel-languageserver-core": "^1.0.4",
         "greyscript-core": "~2.0.3",
         "greyscript-meta": "~4.0.10",
         "greyscript-transpiler": "~1.0.9",
@@ -10216,11 +10216,11 @@
       }
     },
     "greybel-languageserver-browser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/greybel-languageserver-browser/-/greybel-languageserver-browser-1.0.3.tgz",
-      "integrity": "sha512-a5b0jBTLg2Yi5/YkXBoKgBQJphmJDwlWgfv7p0eCY4i/2jZbxIyPnRRoSnNiIjySXh7Vkglc2SOBflymbvCXeA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/greybel-languageserver-browser/-/greybel-languageserver-browser-1.0.4.tgz",
+      "integrity": "sha512-MshHfaAU2EgfguvhTIVddJYcAEz5BQ4EPulktZHdJQ3QESL6NhA34v0yV15JWy+ZqSF4+QCMPPbgXXF7JWjKtQ==",
       "requires": {
-        "greybel-languageserver-core": "^1.0.3",
+        "greybel-languageserver-core": "^1.0.4",
         "greyscript-core": "~2.0.3",
         "greyscript-meta": "~4.0.10",
         "greyscript-transpiler": "~1.0.9",
@@ -10228,9 +10228,9 @@
       }
     },
     "greybel-languageserver-core": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/greybel-languageserver-core/-/greybel-languageserver-core-1.0.3.tgz",
-      "integrity": "sha512-g8gPCKD9/nRKZ3Y/GE19Y88KImnO0IwvDuPQ0cKz8ixwU4Mf4FifEasSB/BumchZUFdWgQ9dkXW7fcjYlmM4RA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/greybel-languageserver-core/-/greybel-languageserver-core-1.0.4.tgz",
+      "integrity": "sha512-4gVXl87Yhqfl4MggAnzeSpE7vskMu9Dj7ArnzCY68SoJRd/LhRMAUHYM7uA1I8kRhP0BAHBtMVVkKM2fAP+CVg==",
       "requires": {
         "color-convert": "^2.0.1",
         "lru-cache": "^7.18.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "soerenwehmeier@googlemail.com"
   },
   "icon": "icon.png",
-  "version": "2.4.12",
+  "version": "2.4.13",
   "repository": {
     "type": "git",
     "url": "git@github.com:ayecue/greybel-vs.git"
@@ -569,8 +569,8 @@
     "greybel-agent": "~1.8.1",
     "greybel-gh-mock-intrinsics": "~5.0.5",
     "greybel-intrinsics": "~5.0.5",
-    "greybel-languageserver": "~1.4.3",
-    "greybel-languageserver-browser": "~1.0.3",
+    "greybel-languageserver": "~1.4.4",
+    "greybel-languageserver-browser": "~1.0.4",
     "greyscript-core": "~2.0.3",
     "greyscript-interpreter": "~2.0.5",
     "greyscript-meta": "~4.0.10",


### PR DESCRIPTION
Includes:
- fix handling textDocument/documentSymbol failed error in ls, which was caused when there was invalid syntax at some point - related to [#243](https://github.com/ayecue/greybel-vs/issues/243)