### PR TITLE
2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1290,3 +1290,8 @@ All notable changes to this project will be documented in this file.
 - fix conflict with comments on beautify - related to [#53](https://github.com/ayecue/miniscript-vs/issues/53) - thanks for reporting to [@Xisec](https://github.com/Xisec)
 - fix edge cases for variable optimizations on uglify
 - fix edge cases for literal optimizations on uglify
+
+## [2.5.1] - 16.09.2024
+
+- fix globals shorthand identifier not getting injected when no literal optimization were happening - related to [#157](https://github.com/ayecue/greybel-js/issues/157) - thanks for reporting to [@smiley8D](https://github.com/smiley8D)
+- fix behaviour of import op in runtime which caused it's payload to be called every time it was imported, instead it's only getting executed once now - related to [#222](https://github.com/ayecue/greybel-js/issues/222) - thanks for reporting to [@smiley8D](https://github.com/smiley8D)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-vs",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-vs",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "dependencies": {
         "@vscode/debugadapter": "^1.51.1",
         "@vscode/debugprotocol": "^1.51.0",
@@ -18,14 +18,14 @@
         "greybel-agent": "~1.8.1",
         "greybel-gh-mock-intrinsics": "~5.1.0",
         "greybel-intrinsics": "~5.1.0",
-        "greybel-languageserver": "~1.6.3",
-        "greybel-languageserver-browser": "~1.2.3",
+        "greybel-languageserver": "~1.6.4",
+        "greybel-languageserver-browser": "~1.2.4",
         "greyscript-core": "~2.1.1",
-        "greyscript-interpreter": "~2.1.0",
+        "greyscript-interpreter": "~2.1.1",
         "greyscript-meta": "~4.0.11",
         "greyscript-meta-web": "~1.0.7",
         "greyscript-textmate": "~1.9.0",
-        "greyscript-transpiler": "~1.2.1",
+        "greyscript-transpiler": "~1.2.2",
         "lru-cache": "^7.14.1",
         "node-json-stream": "~0.2.6",
         "text-encoder-lite": "^2.0.0",
@@ -3735,9 +3735,9 @@
       }
     },
     "node_modules/greybel-interpreter": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-5.1.0.tgz",
-      "integrity": "sha512-3CVwdCdTGe/GA0tuTj7fZwFL8gALzYuI3GuuyvWhV5jgMG7pSSbZJK5fiCPCmU5RHcLxYlgm4upKtpoCrORd8A==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-5.1.1.tgz",
+      "integrity": "sha512-TFMqp3rbTC890sntxH/wH1ksOfM6fnj3cxzX8zAizYIRRTYCM3TV/xKEEdW1pUeRhTzJYtXS8BtNJNQ9o6/h+Q==",
       "license": "MIT",
       "dependencies": {
         "greybel-core": "~2.1.1",
@@ -3756,15 +3756,15 @@
       }
     },
     "node_modules/greybel-languageserver": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/greybel-languageserver/-/greybel-languageserver-1.6.3.tgz",
-      "integrity": "sha512-fsjldX6gt1c7m/O2wjqwRv3zISD95O9NUvd6BTCD3CuQB8ExrrB1GI3J8yb5TmYyMs3seNT01dEqb4zlrBbI+Q==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/greybel-languageserver/-/greybel-languageserver-1.6.4.tgz",
+      "integrity": "sha512-V8ZnXQ8XS5srXTpP6EJTI1XGWheQ2Xp7tMRfA5uobk+T8HQW1Meh2vOiGS+MY6Nqk/9OWG/i2NF/IIs93l8gbA==",
       "license": "ISC",
       "dependencies": {
         "greybel-languageserver-core": "~1.1.3",
         "greyscript-core": "~2.1.1",
         "greyscript-meta": "~4.0.11",
-        "greyscript-transpiler": "~1.2.1",
+        "greyscript-transpiler": "~1.2.2",
         "miniscript-type-analyzer": "~0.9.0"
       },
       "bin": {
@@ -3775,15 +3775,15 @@
       }
     },
     "node_modules/greybel-languageserver-browser": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/greybel-languageserver-browser/-/greybel-languageserver-browser-1.2.3.tgz",
-      "integrity": "sha512-EqRmcBJCuYRWAhyiGiDrul2AZkW5StfF0uEtxMvfotZYr/AkIyBbIeY9Clyjhw7Spa5RJ6uig++odf8DV2YDKA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/greybel-languageserver-browser/-/greybel-languageserver-browser-1.2.4.tgz",
+      "integrity": "sha512-rqJjiBBG32KBU6wt7tTy+rCqKfXUbv+3jjtI6dsMyBy5uQ8KP0HBl2UNvxyiinxAvZDLzmezEhXy/f7qsi0APA==",
       "license": "ISC",
       "dependencies": {
         "greybel-languageserver-core": "~1.1.3",
         "greyscript-core": "~2.1.1",
         "greyscript-meta": "~4.0.11",
-        "greyscript-transpiler": "~1.2.1",
+        "greyscript-transpiler": "~1.2.2",
         "miniscript-type-analyzer": "~0.9.0"
       },
       "engines": {
@@ -3827,9 +3827,9 @@
       }
     },
     "node_modules/greybel-transpiler": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-3.2.1.tgz",
-      "integrity": "sha512-c7oKGOFypxfhRgB4wyHP9ZG8AQbqMsr2yo+ddBv1gN34PowawkJhAKf/Ea9Xou/mSXu1ov1yO7qTvn41Hvjnkw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-3.2.2.tgz",
+      "integrity": "sha512-lbOgZ1l/PVINYpmL2iV8jZkxgiFH4Q8fZRDKs4xBa9WdilNSurTrsRrc7l/Qm5+EN7ojqxlg6hjNLu73jOiT2w==",
       "license": "MIT",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
@@ -3846,12 +3846,12 @@
       }
     },
     "node_modules/greyscript-interpreter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-2.1.0.tgz",
-      "integrity": "sha512-DA1+ZW/eE3BJb6jH+j8UFNfBU6J6nsvVReuVzECt64WIqQDYbcJY2fspvhoWWoijzDevGnkUJEfcDDFZpMYO8Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-2.1.1.tgz",
+      "integrity": "sha512-tcauNr2lEaPoOPuAekisOAROqOG0C3iLjNxBoucRdnLRyiNnyqya0Z6r5U2IksVSZEhh8RBmEyNxQA81FAIb+w==",
       "license": "MIT",
       "dependencies": {
-        "greybel-interpreter": "~5.1.0",
+        "greybel-interpreter": "~5.1.1",
         "greyscript-core": "~2.1.1"
       }
     },
@@ -3881,13 +3881,13 @@
       "integrity": "sha512-RzBZS3Krc24ttEV4I4JmIzGjzkTmCYxcF3a72plusfUNrV1rmKbOaGr5xnNASvYQE79M14a/MGmN5EXtb6yb/w=="
     },
     "node_modules/greyscript-transpiler": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-1.2.1.tgz",
-      "integrity": "sha512-isnMvMabWtLzn+ppYqzQmWyaFyffE4a9rqo0t+1cYvJ5Z6+4mhh78+REkHYxM82A25g241rPENfmdZCGezAz2A==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-1.2.2.tgz",
+      "integrity": "sha512-ipTtDKcIiBjH/2EdTAKyKOJ+O0PrRAyd4x1D8pZfKM0+gQDFIw19Y3omcdvSJCKKDkHO4/MmpZV0DUsmJp2q9Q==",
       "license": "MIT",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
-        "greybel-transpiler": "~3.2.1",
+        "greybel-transpiler": "~3.2.2",
         "greyscript-core": "~2.1.1"
       }
     },
@@ -10187,9 +10187,9 @@
       }
     },
     "greybel-interpreter": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-5.1.0.tgz",
-      "integrity": "sha512-3CVwdCdTGe/GA0tuTj7fZwFL8gALzYuI3GuuyvWhV5jgMG7pSSbZJK5fiCPCmU5RHcLxYlgm4upKtpoCrORd8A==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-5.1.1.tgz",
+      "integrity": "sha512-TFMqp3rbTC890sntxH/wH1ksOfM6fnj3cxzX8zAizYIRRTYCM3TV/xKEEdW1pUeRhTzJYtXS8BtNJNQ9o6/h+Q==",
       "requires": {
         "greybel-core": "~2.1.1",
         "hyperid": "^3.2.0",
@@ -10206,26 +10206,26 @@
       }
     },
     "greybel-languageserver": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/greybel-languageserver/-/greybel-languageserver-1.6.3.tgz",
-      "integrity": "sha512-fsjldX6gt1c7m/O2wjqwRv3zISD95O9NUvd6BTCD3CuQB8ExrrB1GI3J8yb5TmYyMs3seNT01dEqb4zlrBbI+Q==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/greybel-languageserver/-/greybel-languageserver-1.6.4.tgz",
+      "integrity": "sha512-V8ZnXQ8XS5srXTpP6EJTI1XGWheQ2Xp7tMRfA5uobk+T8HQW1Meh2vOiGS+MY6Nqk/9OWG/i2NF/IIs93l8gbA==",
       "requires": {
         "greybel-languageserver-core": "~1.1.3",
         "greyscript-core": "~2.1.1",
         "greyscript-meta": "~4.0.11",
-        "greyscript-transpiler": "~1.2.1",
+        "greyscript-transpiler": "~1.2.2",
         "miniscript-type-analyzer": "~0.9.0"
       }
     },
     "greybel-languageserver-browser": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/greybel-languageserver-browser/-/greybel-languageserver-browser-1.2.3.tgz",
-      "integrity": "sha512-EqRmcBJCuYRWAhyiGiDrul2AZkW5StfF0uEtxMvfotZYr/AkIyBbIeY9Clyjhw7Spa5RJ6uig++odf8DV2YDKA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/greybel-languageserver-browser/-/greybel-languageserver-browser-1.2.4.tgz",
+      "integrity": "sha512-rqJjiBBG32KBU6wt7tTy+rCqKfXUbv+3jjtI6dsMyBy5uQ8KP0HBl2UNvxyiinxAvZDLzmezEhXy/f7qsi0APA==",
       "requires": {
         "greybel-languageserver-core": "~1.1.3",
         "greyscript-core": "~2.1.1",
         "greyscript-meta": "~4.0.11",
-        "greyscript-transpiler": "~1.2.1",
+        "greyscript-transpiler": "~1.2.2",
         "miniscript-type-analyzer": "~0.9.0"
       }
     },
@@ -10255,9 +10255,9 @@
       }
     },
     "greybel-transpiler": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-3.2.1.tgz",
-      "integrity": "sha512-c7oKGOFypxfhRgB4wyHP9ZG8AQbqMsr2yo+ddBv1gN34PowawkJhAKf/Ea9Xou/mSXu1ov1yO7qTvn41Hvjnkw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-3.2.2.tgz",
+      "integrity": "sha512-lbOgZ1l/PVINYpmL2iV8jZkxgiFH4Q8fZRDKs4xBa9WdilNSurTrsRrc7l/Qm5+EN7ojqxlg6hjNLu73jOiT2w==",
       "requires": {
         "blueimp-md5": "^2.19.0",
         "greybel-core": "~2.1.0"
@@ -10272,11 +10272,11 @@
       }
     },
     "greyscript-interpreter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-2.1.0.tgz",
-      "integrity": "sha512-DA1+ZW/eE3BJb6jH+j8UFNfBU6J6nsvVReuVzECt64WIqQDYbcJY2fspvhoWWoijzDevGnkUJEfcDDFZpMYO8Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-2.1.1.tgz",
+      "integrity": "sha512-tcauNr2lEaPoOPuAekisOAROqOG0C3iLjNxBoucRdnLRyiNnyqya0Z6r5U2IksVSZEhh8RBmEyNxQA81FAIb+w==",
       "requires": {
-        "greybel-interpreter": "~5.1.0",
+        "greybel-interpreter": "~5.1.1",
         "greyscript-core": "~2.1.1"
       }
     },
@@ -10304,12 +10304,12 @@
       "integrity": "sha512-RzBZS3Krc24ttEV4I4JmIzGjzkTmCYxcF3a72plusfUNrV1rmKbOaGr5xnNASvYQE79M14a/MGmN5EXtb6yb/w=="
     },
     "greyscript-transpiler": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-1.2.1.tgz",
-      "integrity": "sha512-isnMvMabWtLzn+ppYqzQmWyaFyffE4a9rqo0t+1cYvJ5Z6+4mhh78+REkHYxM82A25g241rPENfmdZCGezAz2A==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/greyscript-transpiler/-/greyscript-transpiler-1.2.2.tgz",
+      "integrity": "sha512-ipTtDKcIiBjH/2EdTAKyKOJ+O0PrRAyd4x1D8pZfKM0+gQDFIw19Y3omcdvSJCKKDkHO4/MmpZV0DUsmJp2q9Q==",
       "requires": {
         "blueimp-md5": "^2.19.0",
-        "greybel-transpiler": "~3.2.1",
+        "greybel-transpiler": "~3.2.2",
         "greyscript-core": "~2.1.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "soerenwehmeier@googlemail.com"
   },
   "icon": "icon.png",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "repository": {
     "type": "git",
     "url": "git@github.com:ayecue/greybel-vs.git"
@@ -569,14 +569,14 @@
     "greybel-agent": "~1.8.1",
     "greybel-gh-mock-intrinsics": "~5.1.0",
     "greybel-intrinsics": "~5.1.0",
-    "greybel-languageserver": "~1.6.3",
-    "greybel-languageserver-browser": "~1.2.3",
+    "greybel-languageserver": "~1.6.4",
+    "greybel-languageserver-browser": "~1.2.4",
     "greyscript-core": "~2.1.1",
-    "greyscript-interpreter": "~2.1.0",
+    "greyscript-interpreter": "~2.1.1",
     "greyscript-meta": "~4.0.11",
     "greyscript-meta-web": "~1.0.7",
     "greyscript-textmate": "~1.9.0",
-    "greyscript-transpiler": "~1.2.1",
+    "greyscript-transpiler": "~1.2.2",
     "lru-cache": "^7.14.1",
     "node-json-stream": "~0.2.6",
     "text-encoder-lite": "^2.0.0",


### PR DESCRIPTION
Includes
- fix globals shorthand identifier not getting injected when no literal optimization were happening - related to [#157](https://github.com/ayecue/greybel-js/issues/157)
- fix behaviour of import op in runtime which caused it's payload to be called every time it was imported, instead it's only getting executed once now - related to [#222](https://github.com/ayecue/greybel-js/issues/222)