### PR TITLE
2.6.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1633,3 +1633,4 @@ All notable changes to this project will be documented in this file.
 
 - split build and run commands into separate commands, tailored to the root file and contextual files - thanks for the suggestion to [@midsubspace](https://github.com/midsubspace)
 - introduce command categories for better organization and discovery
+- run message handling in message-hook on the Unity main thread to prevent Mono-related crashes - fixes rare, seemingly random crashes caused by background task execution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1628,3 +1628,8 @@ All notable changes to this project will be documented in this file.
 - added watch functionality to automatically build when files change - has to be activated
 - added option to define the name of the main output file - thanks for the suggestion to [@EntitySeaker](https://github.com/EntitySeaker)
 - add categories to extension settings to get a better overview
+
+## [2.6.28] - 17.05.2025
+
+- split build and run commands into separate commands, tailored to the root file and contextual files - thanks for the suggestion to [@midsubspace](https://github.com/midsubspace)
+- introduce command categories for better organization and discovery

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The message-hook agent allows you to send messages to the game server through th
 ##### BepInEx 5.x.x
 1. **Download BepInEx 5.x.x**: [BepInEx v5.4.23.2](https://github.com/BepInEx/BepInEx/releases/tag/v5.4.23.2)
     - Install by extracting BepInEx files into your Grey Hack game folder (location of the game executable). See the [Installation Guide](https://docs.bepinex.dev/articles/user_guide/installation/index.html) if needed.
-2. **Add the Plugin**: Download [GreyHackMessageHook5.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/531bb2b769be2c7ac78ddd488b90b4ae8aed7b3c/GreyHackMessageHook5.dll) and move it to the plugins folder in BepInEx.
+2. **Add the Plugin**: Download [GreyHackMessageHook5.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/7db7f5c99659598a42001b51f5a7b397987eea18/GreyHackMessageHook5.dll) and move it to the plugins folder in BepInEx.
 3. **Configure Launch Options (macOS/Linux Only)**:
     - Go to Steam Library > Grey Hack > Properties > Launch Options.
       - **macOS**: `"/path/to/Steam/steamapps/common/Grey Hack/run_bepinex.sh" %command%`
@@ -169,7 +169,7 @@ The message-hook agent allows you to send messages to the game server through th
 ##### BepInEx 6.x.x
 1. **Download BepInEx 6.x.x**: [BepInEx version 6.0.0-pre.2 Unity.Mono](https://github.com/BepInEx/BepInEx/releases/tag/v6.0.0-pre.2)
     - Install by extracting BepInEx files into your Grey Hack game folder (location of the game executable). See the [Installation Guide](https://docs.bepinex.dev/master/articles/user_guide/installation/unity_mono.html) if needed.
-2. **Add the Plugin**: Download [GreyHackMessageHook.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/531bb2b769be2c7ac78ddd488b90b4ae8aed7b3c/GreyHackMessageHook.dll) and move it to the plugins folder in BepInEx.
+2. **Add the Plugin**: Download [GreyHackMessageHook.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/7db7f5c99659598a42001b51f5a7b397987eea18/GreyHackMessageHook.dll) and move it to the plugins folder in BepInEx.
 3. **Configure Launch Options (macOS/Linux Only)**:
     - Go to Steam Library > Grey Hack > Properties > Launch Options.
       - **macOS**: `"/path/to/Steam/steamapps/common/Grey Hack/run_bepinex.sh" %command%`

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can also access these commands through the context menu for quick right-clic
   - **Hoverdocs**: Activate/Deactivate
   - **Formatter**: Activate/Deactivate
   - **File Extensions**: Define allowed file extension
-  - **Root File**: Define the root project file. If not set, the extension will automatically choose a file based on the current context. This determines which file is built or executed
+  - **Root File**: Define the root project file. If not set, the extension will rely on the given context to built or execute files
 - **Create in-game**
   - **Active**: Activate/Deactivate
   - **Auto Compile**: Auto compile and delete source files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-vs",
-  "version": "2.6.27",
+  "version": "2.6.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-vs",
-      "version": "2.6.27",
+      "version": "2.6.28",
       "dependencies": {
         "@vscode/debugadapter": "^1.68.0",
         "@vscode/debugprotocol": "^1.68.0",

--- a/package.json
+++ b/package.json
@@ -81,13 +81,23 @@
     "menus": {
       "editor/title/run": [
         {
-          "command": "greybel.debug.runEditorContents",
-          "when": "resourceLangId == greyscript",
+          "command": "greybel.debug.runFileFromContext",
+          "when": "resourceLangId == greyscript && config.greybel.rootFile == ''",
           "group": "navigation@1"
         },
         {
-          "command": "greybel.debug.debugEditorContents",
-          "when": "resourceLangId == greyscript",
+          "command": "greybel.debug.debugFileFromContext",
+          "when": "resourceLangId == greyscript && config.greybel.rootFile == ''",
+          "group": "navigation@2"
+        },
+        {
+          "command": "greybel.debug.runRootFile",
+          "when": "resourceLangId == greyscript && config.greybel.rootFile != ''",
+          "group": "navigation@1"
+        },
+        {
+          "command": "greybel.debug.debugRootFile",
+          "when": "resourceLangId == greyscript && config.greybel.rootFile != ''",
           "group": "navigation@2"
         }
       ],
@@ -103,9 +113,19 @@
           "group": "1_modification"
         },
         {
-          "command": "greybel.build",
+          "command": "greybel.buildFileFromContext",
           "when": "resourceLangId == greyscript",
           "group": "1_modification"
+        },
+        {
+          "command": "greybel.debug.runFileFromContext",
+          "when": "resourceLangId == greyscript",
+          "group": "z_commands"
+        },
+        {
+          "command": "greybel.debug.debugFileFromContext",
+          "when": "resourceLangId == greyscript",
+          "group": "z_commands"
         },
         {
           "command": "greybel.api",
@@ -147,28 +167,46 @@
       ],
       "explorer/context": [
         {
-          "command": "greybel.build",
+          "command": "greybel.buildFileFromContext",
           "when": "resourceLangId == greyscript",
           "group": "1_modification"
+        },
+        {
+          "command": "greybel.debug.runFileFromContext",
+          "when": "resourceLangId == greyscript",
+          "group": "z_commands"
+        },
+        {
+          "command": "greybel.debug.debugFileFromContext",
+          "when": "resourceLangId == greyscript",
+          "group": "z_commands"
         },
         {
           "command": "greybel.share",
           "when": "resourceLangId == greyscript",
-          "group": "1_modification"
+          "group": "z_commands"
         },
         {
           "command": "greybel.import",
-          "group": "1_modification"
+          "group": "z_commands"
         }
       ],
       "commandPalette": [
         {
-          "command": "greybel.debug.debugEditorContents",
+          "command": "greybel.debug.debugFileFromContext",
           "when": "resourceLangId == greyscript"
         },
         {
-          "command": "greybel.debug.runEditorContents",
+          "command": "greybel.debug.runFileFromContext",
           "when": "resourceLangId == greyscript"
+        },
+        {
+          "command": "greybel.debug.debugRootFile",
+          "when": "resourceLangId == greyscript && config.greybel.rootFile != ''"
+        },
+        {
+          "command": "greybel.debug.runRootFile",
+          "when": "resourceLangId == greyscript && config.greybel.rootFile != ''"
         },
         {
           "command": "greybel.transform.clipboard",
@@ -199,7 +237,11 @@
           "when": "resourceLangId == greyscript"
         },
         {
-          "command": "greybel.build",
+          "command": "greybel.buildRootFile",
+          "when": "resourceLangId == greyscript && config.greybel.rootFile != ''"
+        },
+        {
+          "command": "greybel.buildFileFromContext",
           "when": "resourceLangId == greyscript"
         },
         {
@@ -257,59 +299,89 @@
     "commands": [
       {
         "command": "greybel.gotoError",
+        "category": "Utility",
         "title": "Greybel: Goto Error"
       },
       {
-        "command": "greybel.build",
-        "title": "Greybel: Build"
+        "command": "greybel.buildRootFile",
+        "category": "Build",
+        "title": "Greybel: Build root file"
+      },
+      {
+        "command": "greybel.buildFileFromContext",
+        "category": "Build",
+        "title": "Greybel: Build file from context"
       },
       {
         "command": "greybel.transform.clipboard",
+        "category": "Transform",
         "title": "Greybel: Transform to clipboard"
       },
       {
         "command": "greybel.transform.write",
+        "category": "Transform",
         "title": "Greybel: Transform"
       },
       {
         "command": "greybel.uglify.write",
+        "category": "Transform",
         "title": "Greybel: Uglify"
       },
       {
         "command": "greybel.beautify.write",
+        "category": "Transform",
         "title": "Greybel: Beautify"
       },
       {
         "command": "greybel.share",
+        "category": "Utility",
         "title": "Greybel: Share"
       },
       {
         "command": "greybel.api",
+        "category": "Utility",
         "title": "Greybel: API Documentation"
       },
       {
         "command": "greybel.preview",
+        "category": "Utility",
         "title": "Greybel: Preview output"
       },
       {
         "command": "greybel.import",
+        "category": "Utility",
         "title": "Greybel: Import file into the game"
       },
       {
         "command": "greybel.snippets",
+        "category": "Utility",
         "title": "Greybel: Snippets"
       },
       {
-        "command": "greybel.debug.debugEditorContents",
-        "title": "Debug File",
-        "category": "Mock Debug",
+        "command": "greybel.debug.debugFileFromContext",
+        "title": "Greybel: Debug file from context",
+        "category": "Execution",
         "enablement": "!inDebugMode",
         "icon": "$(debug-alt)"
       },
       {
-        "command": "greybel.debug.runEditorContents",
-        "title": "Run File",
-        "category": "Mock Debug",
+        "command": "greybel.debug.runFileFromContext",
+        "title": "Greybel: Run file from context",
+        "category": "Execution",
+        "enablement": "!inDebugMode",
+        "icon": "$(play)"
+      },
+      {
+        "command": "greybel.debug.debugRootFile",
+        "title": "Greybel: Debug root file",
+        "category": "Execution",
+        "enablement": "!inDebugMode",
+        "icon": "$(debug-alt)"
+      },
+      {
+        "command": "greybel.debug.runRootFile",
+        "title": "Greybel: Run root file",
+        "category": "Execution",
         "enablement": "!inDebugMode",
         "icon": "$(play)"
       }
@@ -345,7 +417,7 @@
           },
           "greybel.rootFile": {
             "type": "string",
-            "description": "Define the root project file. If not set, the extension will automatically choose a file based on the current context. This determines which file is built or executed.",
+            "description": "Define the root project file. If not set, the extension will rely on the given context to built or execute files.",
             "scope": "resource"
           }
         }
@@ -453,7 +525,7 @@
           "greybel.transpiler.watch": {
             "type": "boolean",
             "default": false,
-            "description": "Watch project files for changes and run build automatically.",
+            "description": "Watch project files for changes and build root file automatically.",
             "scope": "resource"
           },
           "greybel.transpiler.outputFilename": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "soerenwehmeier@googlemail.com"
   },
   "icon": "icon.png",
-  "version": "2.6.27",
+  "version": "2.6.28",
   "repository": {
     "type": "git",
     "url": "git@github.com:ayecue/greybel-vs.git"

--- a/src/helper/version-manager.ts
+++ b/src/helper/version-manager.ts
@@ -11,7 +11,7 @@ interface HealthCheckResult {
 }
 
 export class VersionManager {
-  static LATEST_MESSAGE_HOOK_VERSION: string = '0.6.9';
+  static LATEST_MESSAGE_HOOK_VERSION: string = '0.6.10';
   static RESOURCE_LINK: string = 'https://github.com/ayecue/greybel-vs?tab=readme-ov-file#message-hook';
   
   private static _lastNotification: Date | null = null;


### PR DESCRIPTION
Includes:
- split build and run commands into separate commands, tailored to the root file and contextual files
- introduce command categories for better organization and discovery
- run message handling in message-hook on the Unity main thread to prevent Mono-related crashes - fixes rare, seemingly random crashes caused by background task execution