### PR TITLE
2.6.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1651,3 +1651,8 @@ All notable changes to this project will be documented in this file.
 ## [2.6.32] - 29.05.2025
 
 - fix potential desync in client message forwarder related to message-hook
+
+## [2.6.33] - 29.05.2025
+
+- use BepInEx threading helper instead of directly accessing the Unity thread to prevent race conditions in the message hook
+- update assembly to latest version

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ To use the Message Hook, you must first install [BepInEx](https://github.com/Bep
 ### BepInEx 5.x.x
 1. **Download BepInEx 5.x.x**: [BepInEx v5.4.23.2](https://github.com/BepInEx/BepInEx/releases/tag/v5.4.23.2)
     - Install by extracting BepInEx files into your Grey Hack game folder (location of the game executable). See the [Installation Guide](https://docs.bepinex.dev/articles/user_guide/installation/index.html) if needed.
-2. **Add the Plugin**: Download [GreyHackMessageHook5.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/2db21e3566ec3bd1bae9218d19a8a88e1154b616/GreyHackMessageHook5.dll) and move it to the plugins folder in BepInEx.
+2. **Add the Plugin**: Download [GreyHackMessageHook5.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/0bff2cb4adf2013e54b1f88cd391865baa022b67/GreyHackMessageHook5.dll) and move it to the plugins folder in BepInEx.
 3. **Configure Launch Options (macOS/Linux Only)**:
     - Go to Steam Library > Grey Hack > Properties > Launch Options.
       - **macOS**: `"/path/to/Steam/steamapps/common/Grey Hack/run_bepinex.sh" %command%`
@@ -360,7 +360,7 @@ To use the Message Hook, you must first install [BepInEx](https://github.com/Bep
 ### BepInEx 6.x.x
 1. **Download BepInEx 6.x.x**: [BepInEx version 6.0.0-pre.2 Unity.Mono](https://github.com/BepInEx/BepInEx/releases/tag/v6.0.0-pre.2)
     - Install by extracting BepInEx files into your Grey Hack game folder (location of the game executable). See the [Installation Guide](https://docs.bepinex.dev/master/articles/user_guide/installation/unity_mono.html) if needed.
-2. **Add the Plugin**: Download [GreyHackMessageHook.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/2db21e3566ec3bd1bae9218d19a8a88e1154b616/GreyHackMessageHook.dll) and move it to the plugins folder in BepInEx.
+2. **Add the Plugin**: Download [GreyHackMessageHook.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/0bff2cb4adf2013e54b1f88cd391865baa022b67/GreyHackMessageHook.dll) and move it to the plugins folder in BepInEx.
 3. **Configure Launch Options (macOS/Linux Only)**:
     - Go to Steam Library > Grey Hack > Properties > Launch Options.
       - **macOS**: `"/path/to/Steam/steamapps/common/Grey Hack/run_bepinex.sh" %command%`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-vs",
-  "version": "2.6.32",
+  "version": "2.6.33",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-vs",
-      "version": "2.6.32",
+      "version": "2.6.33",
       "dependencies": {
         "@vscode/debugadapter": "^1.68.0",
         "@vscode/debugprotocol": "^1.68.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "soerenwehmeier@googlemail.com"
   },
   "icon": "icon.png",
-  "version": "2.6.32",
+  "version": "2.6.33",
   "repository": {
     "type": "git",
     "url": "git@github.com:ayecue/greybel-vs.git"

--- a/src/helper/version-manager.ts
+++ b/src/helper/version-manager.ts
@@ -11,7 +11,7 @@ interface HealthCheckResult {
 }
 
 export class VersionManager {
-  static LATEST_MESSAGE_HOOK_VERSION: string = '0.6.14';
+  static LATEST_MESSAGE_HOOK_VERSION: string = '0.6.15';
   static RESOURCE_LINK: string = 'https://github.com/ayecue/greybel-vs?tab=readme-ov-file#message-hook';
   
   private static _lastNotification: Date | null = null;


### PR DESCRIPTION
Includes:
- use BepInEx threading helper instead of directly accessing the Unity thread to prevent race conditions in the message hook
- update assembly to latest version