### PR TITLE
2.6.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1656,3 +1656,9 @@ All notable changes to this project will be documented in this file.
 
 - use BepInEx threading helper instead of directly accessing the Unity thread to prevent race conditions in the message hook
 - update assembly to latest version
+
+## [2.6.34] - 03.06.2025
+
+- fix issue that resulted in debugMode option not being properly forwarded, causing breakpoints to not work - related to [#289](https://github.com/ayecue/greybel-vs/issues/337) - thanks for reporting to [dukeofsussex](https://github.com/dukeofsussex)
+- use fs path instead of uri path for the debugger to ensure resources are correctly found on Windows - related to [#289](https://github.com/ayecue/greybel-vs/issues/337) - thanks for reporting to [dukeofsussex](https://github.com/dukeofsussex)
+- add timeout to watcher to prevent watcher being blocked in case of no response

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-vs",
-  "version": "2.6.33",
+  "version": "2.6.34",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-vs",
-      "version": "2.6.33",
+      "version": "2.6.34",
       "dependencies": {
         "@vscode/debugadapter": "^1.68.0",
         "@vscode/debugprotocol": "^1.68.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "soerenwehmeier@googlemail.com"
   },
   "icon": "icon.png",
-  "version": "2.6.33",
+  "version": "2.6.34",
   "repository": {
     "type": "git",
     "url": "git@github.com:ayecue/greybel-vs.git"

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -45,9 +45,10 @@ export function activate(
         type: 'greyscript',
         name: 'Run File',
         request: 'launch',
-        program: resource.toString()
+        // Has to use fsPath since launch.json does not provide normal uri schema
+        program: resource.fsPath
       },
-      { noDebug: true }
+      { noDebug: !isDebug }
     );
   };
 

--- a/src/debug/local/session.ts
+++ b/src/debug/local/session.ts
@@ -191,7 +191,7 @@ export class GreybelDebugSession
     args: ILaunchRequestArguments
   ): Promise<void> {
     const me = this;
-    const uri = Uri.parse(args.program);
+    const uri = Uri.file(args.program);
     const config = vscode.workspace.getConfiguration('greybel');
     const environmentVariables =
       config.get<object>('interpreter.environmentVariables') || {};


### PR DESCRIPTION
- fix issue that resulted in debugMode option not being properly forwarded, causing breakpoints to not work - related to [#289](https://github.com/ayecue/greybel-vs/issues/337)
- use fs path instead of uri path for the debugger to ensure resources are correctly found on Windows - related to [#289](https://github.com/ayecue/greybel-vs/issues/337)
- add timeout to watcher to prevent watcher being blocked in case of no response