### PR TITLE
2.6.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1677,3 +1677,9 @@ All notable changes to this project will be documented in this file.
 ## [2.6.37] - 12.06.2025
 
 - forcefully terminate the execution thread to prevent lingering background processes in the in-game environment - requires the message-hook to be updated
+
+## [2.6.38] - 14.06.2025
+
+- fixed display of type definitions for exported namespaces when using #import (applies to both type analyzer strategies)
+- resolved issues with nested #import statements failing to recognize exported namespaces (applies to both type analyzer strategies)
+- updated LRU cache dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-vs",
-  "version": "2.6.37",
+  "version": "2.6.38",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-vs",
-      "version": "2.6.37",
+      "version": "2.6.38",
       "dependencies": {
         "@vscode/debugadapter": "^1.68.0",
         "@vscode/debugprotocol": "^1.68.0",
@@ -17,8 +17,8 @@
         "css-color-names": "^1.0.1",
         "greybel-gh-mock-intrinsics": "~5.5.12",
         "greybel-intrinsics": "~5.5.5",
-        "greybel-languageserver": "~1.14.3",
-        "greybel-languageserver-browser": "~1.10.3",
+        "greybel-languageserver": "~1.14.7",
+        "greybel-languageserver-browser": "~1.10.7",
         "greyhack-message-hook-client": "~0.6.7",
         "greyscript-core": "~2.5.5",
         "greyscript-interpreter": "~2.5.4",
@@ -26,7 +26,7 @@
         "greyscript-meta-web": "~1.3.3",
         "greyscript-textmate": "~1.11.1",
         "greyscript-transpiler": "~1.7.0",
-        "lru-cache": "^7.14.1",
+        "lru-cache": "^11.1.0",
         "node-json-stream": "~0.2.6",
         "text-encoder-lite": "^2.0.0",
         "text-mesh-transformer": "^1.4.1",
@@ -1871,16 +1871,6 @@
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
-      }
-    },
-    "node_modules/@vscode/vsce/node_modules/lru-cache": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
-      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@vscode/vsce/node_modules/markdown-it": {
@@ -4351,13 +4341,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/greybel-languageserver": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/greybel-languageserver/-/greybel-languageserver-1.14.3.tgz",
-      "integrity": "sha512-vtR2OglQf90SuLwMFGSJ1Ci7VdUbl//33lFuU8KoboRy+AsseeQxdauoU0sP9lvLj1R26FBi9Gotm2swjEtEPA==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/greybel-languageserver/-/greybel-languageserver-1.14.7.tgz",
+      "integrity": "sha512-2Wju+iUqZGeBy7e8tQc9vcGTe54DkEhVepFs0NRKw4/Lz9QW+VCtKca3EIpu8NChNNLiPbKL29linbm6/oMAvQ==",
       "license": "ISC",
       "dependencies": {
         "glob": "^11.0.0",
-        "greybel-languageserver-core": "~1.10.0",
+        "greybel-languageserver-core": "~1.10.4",
         "greyscript-core": "~2.5.5",
         "greyscript-meta": "~4.3.2",
         "greyscript-transpiler": "~1.7.0",
@@ -4371,12 +4361,12 @@
       }
     },
     "node_modules/greybel-languageserver-browser": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/greybel-languageserver-browser/-/greybel-languageserver-browser-1.10.3.tgz",
-      "integrity": "sha512-A7WaB0ZtHrmDOcqb84nwcCN/fzYxHVCKqBBVLocCCFp/QvsV3tF3RtxEh0QZcM58ZDVwSFld5dnNisn/h3SOdQ==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/greybel-languageserver-browser/-/greybel-languageserver-browser-1.10.7.tgz",
+      "integrity": "sha512-wcW1gg6pEC+qNhADjRtxh5wn3loYgX2Jr0lXfds0fpGRafkWlPzr7NM1V6TElyKHJ9woBc1GqmkEWwQLnQIt2Q==",
       "license": "ISC",
       "dependencies": {
-        "greybel-languageserver-core": "~1.10.0",
+        "greybel-languageserver-core": "~1.10.4",
         "greyscript-core": "~2.5.5",
         "greyscript-meta": "~4.3.2",
         "greyscript-transpiler": "~1.7.0",
@@ -4387,14 +4377,14 @@
       }
     },
     "node_modules/greybel-languageserver-core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/greybel-languageserver-core/-/greybel-languageserver-core-1.10.0.tgz",
-      "integrity": "sha512-isRYsh4Ser1j9ZmN+cMPaV88VBurjqXnMHYSFgBupgf4rFXtZtAYhC5xVukte4CSzbe0sKfjRjaG1xP/gN+2CA==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/greybel-languageserver-core/-/greybel-languageserver-core-1.10.4.tgz",
+      "integrity": "sha512-ovM9flyqCYzWwRcj61xiJvKtw49kKN9irx+97YqSVWd0X9qBbjv1SpIvta4+ao5GgrNZfMdqjABjeBkZ8dUUeA==",
       "license": "ISC",
       "dependencies": {
         "color-convert": "^2.0.1",
         "fast-toposort": "^0.1.1",
-        "lru-cache": "^7.18.3",
+        "lru-cache": "^11.1.0",
         "non-blocking-schedule": "^0.2.0",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.11",
@@ -4455,15 +4445,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/greybel-languageserver/node_modules/lru-cache": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
-      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/greybel-languageserver/node_modules/minimatch": {
@@ -5697,11 +5678,12 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "license": "ISC",
       "engines": {
-        "node": ">=12"
+        "node": "20 || >=22"
       }
     },
     "node_modules/markdown-it": {
@@ -9331,12 +9313,6 @@
             "uc.micro": "^2.0.0"
           }
         },
-        "lru-cache": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
-          "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
-          "dev": true
-        },
         "markdown-it": {
           "version": "14.1.0",
           "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
@@ -11225,12 +11201,12 @@
       }
     },
     "greybel-languageserver": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/greybel-languageserver/-/greybel-languageserver-1.14.3.tgz",
-      "integrity": "sha512-vtR2OglQf90SuLwMFGSJ1Ci7VdUbl//33lFuU8KoboRy+AsseeQxdauoU0sP9lvLj1R26FBi9Gotm2swjEtEPA==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/greybel-languageserver/-/greybel-languageserver-1.14.7.tgz",
+      "integrity": "sha512-2Wju+iUqZGeBy7e8tQc9vcGTe54DkEhVepFs0NRKw4/Lz9QW+VCtKca3EIpu8NChNNLiPbKL29linbm6/oMAvQ==",
       "requires": {
         "glob": "^11.0.0",
-        "greybel-languageserver-core": "~1.10.0",
+        "greybel-languageserver-core": "~1.10.4",
         "greyscript-core": "~2.5.5",
         "greyscript-meta": "~4.3.2",
         "greyscript-transpiler": "~1.7.0",
@@ -11266,11 +11242,6 @@
             "@isaacs/cliui": "^8.0.2"
           }
         },
-        "lru-cache": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
-          "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA=="
-        },
         "minimatch": {
           "version": "10.0.1",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
@@ -11291,11 +11262,11 @@
       }
     },
     "greybel-languageserver-browser": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/greybel-languageserver-browser/-/greybel-languageserver-browser-1.10.3.tgz",
-      "integrity": "sha512-A7WaB0ZtHrmDOcqb84nwcCN/fzYxHVCKqBBVLocCCFp/QvsV3tF3RtxEh0QZcM58ZDVwSFld5dnNisn/h3SOdQ==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/greybel-languageserver-browser/-/greybel-languageserver-browser-1.10.7.tgz",
+      "integrity": "sha512-wcW1gg6pEC+qNhADjRtxh5wn3loYgX2Jr0lXfds0fpGRafkWlPzr7NM1V6TElyKHJ9woBc1GqmkEWwQLnQIt2Q==",
       "requires": {
-        "greybel-languageserver-core": "~1.10.0",
+        "greybel-languageserver-core": "~1.10.4",
         "greyscript-core": "~2.5.5",
         "greyscript-meta": "~4.3.2",
         "greyscript-transpiler": "~1.7.0",
@@ -11303,13 +11274,13 @@
       }
     },
     "greybel-languageserver-core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/greybel-languageserver-core/-/greybel-languageserver-core-1.10.0.tgz",
-      "integrity": "sha512-isRYsh4Ser1j9ZmN+cMPaV88VBurjqXnMHYSFgBupgf4rFXtZtAYhC5xVukte4CSzbe0sKfjRjaG1xP/gN+2CA==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/greybel-languageserver-core/-/greybel-languageserver-core-1.10.4.tgz",
+      "integrity": "sha512-ovM9flyqCYzWwRcj61xiJvKtw49kKN9irx+97YqSVWd0X9qBbjv1SpIvta4+ao5GgrNZfMdqjABjeBkZ8dUUeA==",
       "requires": {
         "color-convert": "^2.0.1",
         "fast-toposort": "^0.1.1",
-        "lru-cache": "^7.18.3",
+        "lru-cache": "^11.1.0",
         "non-blocking-schedule": "^0.2.0",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.11",
@@ -12223,9 +12194,9 @@
       }
     },
     "lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A=="
     },
     "markdown-it": {
       "version": "12.3.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "soerenwehmeier@googlemail.com"
   },
   "icon": "icon.png",
-  "version": "2.6.37",
+  "version": "2.6.38",
   "repository": {
     "type": "git",
     "url": "git@github.com:ayecue/greybel-vs.git"
@@ -711,8 +711,8 @@
     "css-color-names": "^1.0.1",
     "greybel-gh-mock-intrinsics": "~5.5.12",
     "greybel-intrinsics": "~5.5.5",
-    "greybel-languageserver": "~1.14.3",
-    "greybel-languageserver-browser": "~1.10.3",
+    "greybel-languageserver": "~1.14.7",
+    "greybel-languageserver-browser": "~1.10.7",
     "greyhack-message-hook-client": "~0.6.7",
     "greyscript-core": "~2.5.5",
     "greyscript-interpreter": "~2.5.4",
@@ -720,7 +720,7 @@
     "greyscript-meta-web": "~1.3.3",
     "greyscript-textmate": "~1.11.1",
     "greyscript-transpiler": "~1.7.0",
-    "lru-cache": "^7.14.1",
+    "lru-cache": "^11.1.0",
     "node-json-stream": "~0.2.6",
     "text-encoder-lite": "^2.0.0",
     "text-mesh-transformer": "^1.4.1",

--- a/src/helper/document-manager.ts
+++ b/src/helper/document-manager.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 import { ASTChunkGreyScript, Parser } from 'greyscript-core';
-import LRU from 'lru-cache';
+import { LRUCache as LRU } from 'lru-cache';
 import { ASTBaseBlockWithScope } from 'miniscript-core';
 import vscode, { TextDocument, Uri } from 'vscode';
 


### PR DESCRIPTION
Includes:
- fixed display of type definitions for exported namespaces when using #import (applies to both type analyzer strategies)
- resolved issues with nested #import statements failing to recognize exported namespaces (applies to both type analyzer strategies)
- updated LRU cache dependency