### PR TITLE
2.6.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1683,3 +1683,7 @@ All notable changes to this project will be documented in this file.
 - fixed display of type definitions for exported namespaces when using #import (applies to both type analyzer strategies)
 - resolved issues with nested #import statements failing to recognize exported namespaces (applies to both type analyzer strategies)
 - updated LRU cache dependency
+
+## [2.6.39] - 28.06.2025
+
+- use bepinex traverse to retrieve helperImport property in interpreter patch to prevent randomly occuring crashes - requires the message-hook to be updated

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ To use the Message Hook, you must first install [BepInEx](https://github.com/Bep
 ### BepInEx 5.x.x
 1. **Download BepInEx 5.x.x**: [BepInEx v5.4.23.2](https://github.com/BepInEx/BepInEx/releases/tag/v5.4.23.2)
     - Install by extracting BepInEx files into your Grey Hack game folder (location of the game executable). See the [Installation Guide](https://docs.bepinex.dev/articles/user_guide/installation/index.html) if needed.
-2. **Add the Plugin**: Download [GreyHackMessageHook5.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/3287b1852de4dcdc72a8bb0e0e75080dba6c55f4/GreyHackMessageHook5.dll) and move it to the plugins folder in BepInEx.
+2. **Add the Plugin**: Download [GreyHackMessageHook5.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/dfa5e1e5333139d32d1bb0f40b59b103723f2dae/GreyHackMessageHook5.dll) and move it to the plugins folder in BepInEx.
 3. **Configure Launch Options (macOS/Linux Only)**:
     - Go to Steam Library > Grey Hack > Properties > Launch Options.
       - **macOS**: `"/path/to/Steam/steamapps/common/Grey Hack/run_bepinex.sh" %command%`
@@ -360,7 +360,7 @@ To use the Message Hook, you must first install [BepInEx](https://github.com/Bep
 ### BepInEx 6.x.x
 1. **Download BepInEx 6.x.x**: [BepInEx version 6.0.0-pre.2 Unity.Mono](https://github.com/BepInEx/BepInEx/releases/tag/v6.0.0-pre.2)
     - Install by extracting BepInEx files into your Grey Hack game folder (location of the game executable). See the [Installation Guide](https://docs.bepinex.dev/master/articles/user_guide/installation/unity_mono.html) if needed.
-2. **Add the Plugin**: Download [GreyHackMessageHook.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/3287b1852de4dcdc72a8bb0e0e75080dba6c55f4/GreyHackMessageHook.dll) and move it to the plugins folder in BepInEx.
+2. **Add the Plugin**: Download [GreyHackMessageHook.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/dfa5e1e5333139d32d1bb0f40b59b103723f2dae/GreyHackMessageHook.dll) and move it to the plugins folder in BepInEx.
 3. **Configure Launch Options (macOS/Linux Only)**:
     - Go to Steam Library > Grey Hack > Properties > Launch Options.
       - **macOS**: `"/path/to/Steam/steamapps/common/Grey Hack/run_bepinex.sh" %command%`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-vs",
-  "version": "2.6.38",
+  "version": "2.6.39",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-vs",
-      "version": "2.6.38",
+      "version": "2.6.39",
       "dependencies": {
         "@vscode/debugadapter": "^1.68.0",
         "@vscode/debugprotocol": "^1.68.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "soerenwehmeier@googlemail.com"
   },
   "icon": "icon.png",
-  "version": "2.6.38",
+  "version": "2.6.39",
   "repository": {
     "type": "git",
     "url": "git@github.com:ayecue/greybel-vs.git"

--- a/src/helper/version-manager.ts
+++ b/src/helper/version-manager.ts
@@ -11,7 +11,7 @@ interface HealthCheckResult {
 }
 
 export class VersionManager {
-  static LATEST_MESSAGE_HOOK_VERSION: string = '0.6.17';
+  static LATEST_MESSAGE_HOOK_VERSION: string = '0.6.18';
   static RESOURCE_LINK: string = 'https://github.com/ayecue/greybel-vs?tab=readme-ov-file#message-hook';
   
   private static _lastNotification: Date | null = null;


### PR DESCRIPTION
Includes:
- use bepinex traverse to retrieve helperImport property in interpreter patch to prevent randomly occuring crashes - requires the message-hook to be updated