### PR TITLE
2.6.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1700,5 +1700,5 @@ All notable changes to this project will be documented in this file.
 
 - updated message-hook to use latest assembly and unity version - the prior message-hook version seems to work fine with the latest Grey Hack patch, therefore this update is rather optional
 - updated message-hook-client regarding login payload
-- significantly reduced build time by caching I/O operations - thanks for reporting to IDelta
+- significantly reduced build time, for projects with a lot of small files, by caching I/O operations - thanks for reporting to IDelta
 - prevented unnecessary deletion retries during auto-compile - thanks for reporting to Dough San and IDelta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1700,3 +1700,5 @@ All notable changes to this project will be documented in this file.
 
 - updated message-hook to use latest assembly and unity version - the prior message-hook version seems to work fine with the latest Grey Hack patch, therefore this update is rather optional
 - updated message-hook-client regarding login payload
+- significantly reduced build time by caching I/O operations - thanks for reporting to IDelta
+- prevented unnecessary deletion retries during auto-compile - thanks for reporting to Dough San and IDelta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1695,3 +1695,8 @@ All notable changes to this project will be documented in this file.
 ## [2.6.41] - 11.07.2025
 
 - fixed script crashing on user_input due to missing cpu usage instance initialisation, related to in-game env - requires the message-hook to be updated
+
+## [2.6.42] - 17.07.2025
+
+- updated message-hook to use latest assembly and unity version - the prior message-hook version seems to work fine with the latest Grey Hack patch, therefore this update is rather optional
+- updated message-hook-client regarding login payload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1696,7 +1696,7 @@ All notable changes to this project will be documented in this file.
 
 - fixed script crashing on user_input due to missing cpu usage instance initialisation, related to in-game env - requires the message-hook to be updated
 
-## [2.6.42] - 17.07.2025
+## [2.6.42] - 18.07.2025
 
 - updated message-hook to use latest assembly and unity version - the prior message-hook version seems to work fine with the latest Grey Hack patch, therefore this update is rather optional
 - updated message-hook-client regarding login payload

--- a/README.md
+++ b/README.md
@@ -356,6 +356,8 @@ To use the Message Hook, you must first install [BepInEx](https://github.com/Bep
 
 If you prefer video over written instructions, there’s also a [tutorial](#tutorial-video) created by [@redit0](https://github.com/redit0) that walks you through the setup process.
 
+**Note**: BepInEx 6.x.x is in a pre-release state and may be less stable than 5.x.x. If you experience frequent crashes, consider switching back to version 5.x.x.
+
 ### BepInEx 5.x.x
 1. **Download BepInEx 5.x.x**: [BepInEx v5.4.23.2](https://github.com/BepInEx/BepInEx/releases/tag/v5.4.23.2)
     - Install by extracting BepInEx files into your Grey Hack game folder (location of the game executable). See the [Installation Guide](https://docs.bepinex.dev/articles/user_guide/installation/index.html) if needed.
@@ -376,9 +378,24 @@ If you prefer video over written instructions, there’s also a [tutorial](#tuto
       - **Linux**: `"/path/to/.steam/steam/steamapps/common/Grey Hack/run_bepinex.sh" || %command%`
 4. **Launch Grey Hack** via Steam to load BepInEx 6 with the plugin.
 
-**Note**: BepInEx 6.x.x is in a pre-release state and may be less stable than 5.x.x. If you experience frequent crashes, consider switching back to version 5.x.x.
+### Troubleshooting
 
-**Reminder**: Grey Hack must be running for this agent to function properly.
+#### Grey Hack is crashing on startup on macOS (Apple Silicon)
+
+Since version `0.9.5694`, Grey Hack runs natively on Apple Silicon Macs. When used with BepInEx, this can cause crashes, specifically the following error: 
+```bash
+EntryPointNotFoundException: SteamInternal_SteamAPI_Init assembly:<unknown assembly> type:<unknown type> member:(null)
+  at (wrapper managed-to-native) Steamworks.SteamAPI+Native.SteamInternal_SteamAPI_Init(string,intptr)
+  at Steamworks.SteamAPI.Init (System.String pszInternalCheckInterfaceVersions, System.String& pOutErrMsg) [0x0000e] in <6edbf121be6b4184ba49a762e217ee3b>:0 
+  at Steamworks.SteamClient.Init (System.UInt32 appid, System.Boolean asyncCallbacks) [0x000f4] in <6edbf121be6b4184ba49a762e217ee3b>:0 
+  at ClientSteam.Start () [0x0001e] in <5900bf36cb6f404fa6809df9b65e2cde>:0 
+UnityEngine.DebugLogHandler:Internal_LogException(Exception, Object)
+UnityEngine.DebugLogHandler:LogException(Exception, Object)
+UnityEngine.Logger:LogException(Exception, Object)
+UnityEngine.Debug:LogException(Exception)
+ClientSteam:Start()
+```
+You can fix this crash by deleting the `libsteam_api.dylib` file located in the game's root directory. This does not appear to impact gameplay.
 
 ## Preview Output
 

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ UnityEngine.Logger:LogException(Exception, Object)
 UnityEngine.Debug:LogException(Exception)
 ClientSteam:Start()
 ```
-You can fix this crash by deleting the `libsteam_api.dylib` file located in the game's root directory. This does not appear to impact gameplay.
+You can fix this crash by deleting the `libsteam_api.dylib` file located in the game's root directory. This crash is caused by multiple versions of `libsteam_api.dylib` being present, leading to the wrong library loading first. Deleting the duplicate `libsteam_api.dylib` in the game root prevents this conflict, allowing the correct version to load. This fix does not appear to affect gameplay or functionality.
 
 ## Preview Output
 

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ If you prefer video over written instructions, there’s also a [tutorial](#tuto
 ### BepInEx 5.x.x
 1. **Download BepInEx 5.x.x**: [BepInEx v5.4.23.2](https://github.com/BepInEx/BepInEx/releases/tag/v5.4.23.2)
     - Install by extracting BepInEx files into your Grey Hack game folder (location of the game executable). See the [Installation Guide](https://docs.bepinex.dev/articles/user_guide/installation/index.html) if needed.
-2. **Add the Plugin**: Download [GreyHackMessageHook5.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/f293fb6cc847b77f45739a5b1b1b9be1c7a2bb90/GreyHackMessageHook5.dll) and move it to the plugins folder in BepInEx.
+2. **Add the Plugin**: Download [GreyHackMessageHook5.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/8d080256b2f73177b793656159d48075f81d1757/GreyHackMessageHook5.dll) and move it to the plugins folder in BepInEx.
 3. **Configure Launch Options (macOS/Linux Only)**:
     - Go to Steam Library > Grey Hack > Properties > Launch Options.
       - **macOS**: `"/path/to/Steam/steamapps/common/Grey Hack/run_bepinex.sh" %command%`
@@ -371,7 +371,7 @@ If you prefer video over written instructions, there’s also a [tutorial](#tuto
 ### BepInEx 6.x.x
 1. **Download BepInEx 6.x.x**: [BepInEx version 6.0.0-pre.2 Unity.Mono](https://github.com/BepInEx/BepInEx/releases/tag/v6.0.0-pre.2)
     - Install by extracting BepInEx files into your Grey Hack game folder (location of the game executable). See the [Installation Guide](https://docs.bepinex.dev/master/articles/user_guide/installation/unity_mono.html) if needed.
-2. **Add the Plugin**: Download [GreyHackMessageHook.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/f293fb6cc847b77f45739a5b1b1b9be1c7a2bb90/GreyHackMessageHook.dll) and move it to the plugins folder in BepInEx.
+2. **Add the Plugin**: Download [GreyHackMessageHook.dll](https://gist.github.com/ayecue/b45998fa9a8869e4bbfff0f448ac98f9/raw/8d080256b2f73177b793656159d48075f81d1757/GreyHackMessageHook.dll) and move it to the plugins folder in BepInEx.
 3. **Configure Launch Options (macOS/Linux Only)**:
     - Go to Steam Library > Grey Hack > Properties > Launch Options.
       - **macOS**: `"/path/to/Steam/steamapps/common/Grey Hack/run_bepinex.sh" %command%`

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "greybel-intrinsics": "~5.5.5",
         "greybel-languageserver": "~1.14.7",
         "greybel-languageserver-browser": "~1.10.7",
-        "greyhack-message-hook-client": "~0.6.7",
+        "greyhack-message-hook-client": "~0.6.8",
         "greyscript-core": "~2.5.5",
         "greyscript-interpreter": "~2.5.4",
         "greyscript-meta": "~4.3.2",
@@ -4502,9 +4502,9 @@
       }
     },
     "node_modules/greyhack-message-hook-client": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/greyhack-message-hook-client/-/greyhack-message-hook-client-0.6.7.tgz",
-      "integrity": "sha512-AcDKekYZQU022BRzpZMOwLtoYXV7E6CJ6q6qqnBUpkN7gYlxJjvCR36uPwssOvl2RWFH0hQB5ZejGHdvzDA7nA==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/greyhack-message-hook-client/-/greyhack-message-hook-client-0.6.8.tgz",
+      "integrity": "sha512-91Orgt8pWOUYW27WEnwOCUJucwfB8A+qz1LiIe334sFsVcbuOMzQPxJQb56h2PNm3cW9c+WAodqPcX3ZGNt6mQ==",
       "license": "MIT",
       "dependencies": {
         "node-json-stream": "^0.2.6"
@@ -11309,9 +11309,9 @@
       }
     },
     "greyhack-message-hook-client": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/greyhack-message-hook-client/-/greyhack-message-hook-client-0.6.7.tgz",
-      "integrity": "sha512-AcDKekYZQU022BRzpZMOwLtoYXV7E6CJ6q6qqnBUpkN7gYlxJjvCR36uPwssOvl2RWFH0hQB5ZejGHdvzDA7nA==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/greyhack-message-hook-client/-/greyhack-message-hook-client-0.6.8.tgz",
+      "integrity": "sha512-91Orgt8pWOUYW27WEnwOCUJucwfB8A+qz1LiIe334sFsVcbuOMzQPxJQb56h2PNm3cW9c+WAodqPcX3ZGNt6mQ==",
       "requires": {
         "node-json-stream": "^0.2.6"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-vs",
-  "version": "2.6.41",
+  "version": "2.6.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-vs",
-      "version": "2.6.41",
+      "version": "2.6.42",
       "dependencies": {
         "@vscode/debugadapter": "^1.68.0",
         "@vscode/debugprotocol": "^1.68.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "soerenwehmeier@googlemail.com"
   },
   "icon": "icon.png",
-  "version": "2.6.41",
+  "version": "2.6.42",
   "repository": {
     "type": "git",
     "url": "git@github.com:ayecue/greybel-vs.git"

--- a/package.json
+++ b/package.json
@@ -713,7 +713,7 @@
     "greybel-intrinsics": "~5.5.5",
     "greybel-languageserver": "~1.14.7",
     "greybel-languageserver-browser": "~1.10.7",
-    "greyhack-message-hook-client": "~0.6.7",
+    "greyhack-message-hook-client": "~0.6.8",
     "greyscript-core": "~2.5.5",
     "greyscript-interpreter": "~2.5.4",
     "greyscript-meta": "~4.3.2",

--- a/src/build/auto-compile-helper.ts
+++ b/src/build/auto-compile-helper.ts
@@ -84,13 +84,13 @@ export const generateAutoCompileCode = (
       currentFolderPath = pop(remainingFolderPaths)
 
       while currentFolderPath != null
-        if rootDirectory.indexOf(currentFolderPath) == 0 then
+        if indexOf(rootDirectory, currentFolderPath) == 0 then
           currentFolderPath = pop(remainingFolderPaths)
           continue
         end if
 
         folder = tryGetFile(myComputer, currentFolderPath)
-        if folder and folder.get_files.len == 0 and folder.get_folders.len == 0 then
+        if folder and len(get_files(folder)) == 0 and len(get_folders(folder)) == 0 then
           push(remainingFolderPaths, path(parent(folder)))
           delete(folder)
           print("Deleted " + folder.path)

--- a/src/build/auto-compile-helper.ts
+++ b/src/build/auto-compile-helper.ts
@@ -66,7 +66,7 @@ export const generateAutoCompileCode = (
 
       for filePath in filePaths
         absPath = rootDirectory + filePath
-        entity = tryGetFile(myComputer, absPath)
+        entity = File(myComputer, absPath)
 
         if not entity then
           print("Couldn't find " + absPath)
@@ -89,7 +89,7 @@ export const generateAutoCompileCode = (
           continue
         end if
 
-        folder = tryGetFile(myComputer, currentFolderPath)
+        folder = File(myComputer, currentFolderPath)
         if folder and len(get_files(folder)) == 0 and len(get_folders(folder)) == 0 then
           push(remainingFolderPaths, path(parent(folder)))
           delete(folder)

--- a/src/debug/agent/handler.ts
+++ b/src/debug/agent/handler.ts
@@ -1,6 +1,6 @@
 import { ContextAgent } from "greyhack-message-hook-client";
 import vscode, { SourceBreakpoint, Uri } from 'vscode';
-import { findExistingPath, tryToDecode } from "../../helper/fs";
+import { GlobalFileSystemManager } from "../../helper/fs";
 import PseudoTerminal from "../pseudo-terminal";
 import EventEmitter from "events";
 import { OutputHandler } from "./output";
@@ -46,7 +46,7 @@ interface ContextBreakpoint {
 }
 
 async function resolveFileExtension(path: string, allowedFileExtensions: string[]): Promise<Uri | null> {
-  return await findExistingPath(
+  return await GlobalFileSystemManager.findExistingPath(
     Uri.file(path),
     ...allowedFileExtensions.map((ext) => Uri.file(`${path}.${ext}`))
   );
@@ -97,7 +97,7 @@ export class SessionHandler extends EventEmitter {
       throw new Error('Can only start in-game debug session with singleplayer running!');
     }
 
-    const content = await tryToDecode(path);
+    const content = await GlobalFileSystemManager.tryToDecode(path);
     const breakpoints = vscode.debug.breakpoints.filter((bp: SourceBreakpoint) => {
       return bp.enabled;
     }).map((bp: SourceBreakpoint) => {
@@ -290,7 +290,7 @@ export class SessionHandler extends EventEmitter {
       await this._instance.resolvedFile(path, null);
       return;
     }
-    const content = await tryToDecode(resolvedPath);
+    const content = await GlobalFileSystemManager.tryToDecode(resolvedPath);
     await this._instance.resolvedFile(resolvedPath.fsPath, content);
   }
 

--- a/src/debug/agent/session.ts
+++ b/src/debug/agent/session.ts
@@ -12,7 +12,7 @@ import { DebugProtocol } from '@vscode/debugprotocol';
 import { ModifierType } from 'another-ansi';
 import vscode, { Uri } from 'vscode';
 
-import { PseudoFS } from '../../helper/fs';
+import { GlobalFileSystemManager } from '../../helper/fs';
 import { showCustomErrorMessage } from '../../helper/show-custom-error';
 import { ansiProvider, useColor } from '../../helper/text-mesh-transform';
 import { getPreviewInstance } from '../../preview';
@@ -393,7 +393,7 @@ export class AgentDebugSession
         const sf: DebugProtocol.StackFrame = new StackFrame(
           f.index,
           f.name,
-          new Source(PseudoFS.basename(f.file), f.file),
+          new Source(GlobalFileSystemManager.basename(f.file), f.file),
           f.line,
           f.column
         );

--- a/src/debug/local/session.ts
+++ b/src/debug/local/session.ts
@@ -29,7 +29,7 @@ import { init as initIntrinsics } from 'greybel-intrinsics';
 import { Interpreter } from 'greyscript-interpreter';
 import vscode, { Uri } from 'vscode';
 
-import { PseudoFS } from '../../helper/fs';
+import { GlobalFileSystemManager } from '../../helper/fs';
 import { showCustomErrorMessage } from '../../helper/show-custom-error';
 import { ansiProvider, useColor } from '../../helper/text-mesh-transform';
 import { getPreviewInstance } from '../../preview';
@@ -457,7 +457,7 @@ export class GreybelDebugSession
         const sf: DebugProtocol.StackFrame = new StackFrame(
           f.index,
           f.name,
-          new Source(PseudoFS.basename(f.file), f.file),
+          new Source(GlobalFileSystemManager.basename(f.file), f.file),
           f.line,
           f.column
         );

--- a/src/helper/env-mapper.ts
+++ b/src/helper/env-mapper.ts
@@ -1,6 +1,6 @@
 import { escapeMSString } from './escape-ms-string.js';
 import { Uri, workspace } from 'vscode';
-import { tryToDecode } from './fs.js';
+import { GlobalFileSystemManager } from './fs.js';
 
 function readVarLines(
   varLines: string[],
@@ -30,7 +30,7 @@ async function loadConfigFile(
   filepath: Uri,
   map: { [key: string]: string }
 ): Promise<{ [key: string]: string }> {
-  const content = await tryToDecode(filepath);
+  const content = await GlobalFileSystemManager.tryToDecode(filepath);
 
   if (content == null) {
     return map;

--- a/src/helper/fs.ts
+++ b/src/helper/fs.ts
@@ -99,7 +99,7 @@ export class FileSystemManagerWithCache extends FileSystemManager {
     const key = targetUri.toString();
     const result = this.fileContentCache.get(key);
 
-    if (result) {
+    if (result !== undefined) {
       return result;
     }
 
@@ -112,7 +112,7 @@ export class FileSystemManagerWithCache extends FileSystemManager {
     const key = mainUri.toString();
     const cachedUri = this.pathResolveCache.get(key);
 
-    if (cachedUri) {
+    if (cachedUri !== undefined) {
       return cachedUri;
     }
 

--- a/src/helper/fs.ts
+++ b/src/helper/fs.ts
@@ -6,81 +6,120 @@ import vscode, { Uri } from 'vscode';
 
 const fs = vscode.workspace.fs;
 
-export class PseudoFS {
-  static basename(file: string): string {
+export class FileSystemManager {
+  basename(file: string): string {
     return path.basename(file);
   }
 
-  static dirname(file: string): string {
+  dirname(file: string): string {
     return path.dirname(file);
   }
 
-  static resolve(file: string): string {
+  resolve(file: string): string {
     return path.resolve(file);
   }
-}
 
-export async function tryToGet(
-  targetUri: Uri,
-  unsafe: boolean = false
-): Promise<Uint8Array | null> {
-  try {
-    return await fs.readFile(targetUri);
-  } catch (err) {
-    if (!unsafe) console.error(err);
-  }
-
-  return null;
-}
-
-export function getWorkspaceFolderUri(source: Uri): Uri | null {
-  const uris = vscode.workspace.workspaceFolders;
-  return (
-    uris.find((folderUri) => source.path.startsWith(folderUri.uri.path))?.uri ??
-    null
-  );
-}
-
-export async function findExistingPath(
-  mainUri: Uri,
-  ...altUris: Uri[]
-): Promise<Uri | null> {
-  const mainItem = await tryToGet(mainUri, true);
-  if (mainItem != null) return mainUri;
-
-  if (altUris.length === 0) {
-    return null;
-  }
-
-  try {
-    const altItemUri = await Promise.any(
-      altUris.map(async (uri) => {
-        const item = await tryToGet(uri, true);
-        if (item != null) return uri;
-        throw new Error('Alternative path could not resolve');
-      })
-    );
-
-    if (altItemUri != null) {
-      return altItemUri;
+  async tryToGet(
+    targetUri: Uri,
+    unsafe: boolean = false
+  ): Promise<Uint8Array | null> {
+    try {
+      return await fs.readFile(targetUri);
+    } catch (err) {
+      if (!unsafe) console.error(err);
     }
 
     return null;
-  } catch (err) {
+  }
+
+  async tryToDecode(
+    targetUri: Uri,
+    unsafe: boolean = false
+  ): Promise<string | null> {
+    const out = await this.tryToGet(targetUri, unsafe);
+
+    if (out != null) {
+      const content = new TextDecoder().decode(out);
+      return crlf(content, LF);
+    }
+
     return null;
   }
-}
 
-export async function tryToDecode(
-  targetUri: Uri,
-  unsafe: boolean = false
-): Promise<string | null> {
-  const out = await tryToGet(targetUri, unsafe);
-
-  if (out != null) {
-    const content = new TextDecoder().decode(out);
-    return crlf(content, LF);
+  getWorkspaceFolderUri(source: Uri): Uri | null {
+    const uris = vscode.workspace.workspaceFolders;
+    return (
+      uris.find((folderUri) => source.path.startsWith(folderUri.uri.path))?.uri ??
+      null
+    );
   }
 
-  return null;
+  async findExistingPath(
+    mainUri: Uri,
+    ...altUris: Uri[]
+  ): Promise<Uri | null> {
+    const mainItem = await this.tryToGet(mainUri, true);
+    if (mainItem != null) return mainUri;
+
+    if (altUris.length === 0) {
+      return null;
+    }
+
+    try {
+      const altItemUri = await Promise.any(
+        altUris.map(async (uri) => {
+          const item = await this.tryToGet(uri, true);
+          if (item != null) return uri;
+          throw new Error('Alternative path could not resolve');
+        })
+      );
+
+      if (altItemUri != null) {
+        return altItemUri;
+      }
+
+      return null;
+    } catch (err) {
+      return null;
+    }
+  }
 }
+
+export class FileSystemManagerWithCache extends FileSystemManager {
+  private fileContentCache: Map<string, Uint8Array>;
+  private pathResolveCache: Map<string, Uri>;
+
+  constructor() {
+    super();
+    this.fileContentCache = new Map<string, Uint8Array>();
+    this.pathResolveCache = new Map<string, Uri>();
+  }
+
+  async tryToGet(targetUri: Uri, unsafe: boolean = false): Promise<Uint8Array | null> {
+    const key = targetUri.toString();
+    const result = this.fileContentCache.get(key);
+
+    if (result) {
+      return result;
+    }
+
+    const content = await super.tryToGet(targetUri, unsafe);
+    this.fileContentCache.set(key, content);
+    return content;
+  }
+
+  async findExistingPath(mainUri: Uri, ...altUris: Uri[]): Promise<Uri | null> {
+    const key = mainUri.toString();
+    const cachedUri = this.pathResolveCache.get(key);
+
+    if (cachedUri) {
+      return cachedUri;
+    }
+
+    const result = await super.findExistingPath(mainUri, ...altUris);
+    this.pathResolveCache.set(key, result);
+    return result;
+  }
+}
+
+export const GlobalFileSystemManager = new FileSystemManager();

--- a/src/import.ts
+++ b/src/import.ts
@@ -5,7 +5,7 @@ import vscode, {
 
 import { showCustomErrorMessage } from './helper/show-custom-error';
 import { executeImport } from './build/importer';
-import { tryToDecode } from './helper/fs';
+import { GlobalFileSystemManager } from './helper/fs';
 import { getIngameDirectory } from './helper/get-ingame-directory';
 import { VersionManager } from './helper/version-manager';
 
@@ -47,7 +47,7 @@ export function activate(context: ExtensionContext) {
       const port = config.get<number>('createIngame.port');
       const ingameDirectory = await getIngameDirectory(config);
       const filesWithContent = await Promise.all(files.map(async (file) => {
-        const content = await tryToDecode(file);
+        const content = await GlobalFileSystemManager.tryToDecode(file);
 
         return {
           path: file.toString(),

--- a/src/language-client-web.ts
+++ b/src/language-client-web.ts
@@ -4,7 +4,7 @@ import {
   LanguageClient,
   LanguageClientOptions
 } from 'vscode-languageclient/lib/browser/main';
-import { tryToDecode } from './helper/fs';
+import { GlobalFileSystemManager } from './helper/fs';
 
 let client: LanguageClient;
 
@@ -42,7 +42,7 @@ function createClient(context: ExtensionContext, worker: Worker) {
   client.onRequest('custom/read-file', async (params: string) => {
     const { uri } = JSON.parse(params) as { uri: string };
     const uriInstance = Uri.parse(uri);
-    const fileContent = await tryToDecode(uriInstance, true);
+    const fileContent = await GlobalFileSystemManager.tryToDecode(uriInstance, true);
     return fileContent;
   });
 


### PR DESCRIPTION
Includes:
- updated message-hook to use latest assembly and unity version - the prior message-hook version seems to work fine with the latest Grey Hack patch, therefore this update is rather optional
- updated message-hook-client regarding login payload
- significantly reduced build time by caching I/O operations
- prevented unnecessary deletion retries during auto-compile