### PR TITLE
2.6.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1764,3 +1764,8 @@ All notable changes to this project will be documented in this file.
 ## [2.6.54] - 22.08.2025
 
 - improve transpiler module wrapper approach, properly handles now if an export is not defined in a module - related to [#307](https://github.com/ayecue/greybel-js/issues/307) - thanks for reporting to [@M3rluzzo](https://github.com/M3rluzzo)
+
+## [2.6.55] - 23.08.2025
+
+- allow overidding of globals, locals and outer in interpreter runtime
+- remove check on map.push in case of already existing key to emulate in-game behaviour

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-vs",
-  "version": "2.6.54",
+  "version": "2.6.55",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-vs",
-      "version": "2.6.54",
+      "version": "2.6.55",
       "dependencies": {
         "@vscode/debugadapter": "^1.68.0",
         "@vscode/debugprotocol": "^1.68.0",
@@ -15,13 +15,13 @@
         "color-convert": "^2.0.1",
         "crlf-normalize": "^1.0.20",
         "css-color-names": "^1.0.1",
-        "greybel-gh-mock-intrinsics": "~5.6.0",
-        "greybel-intrinsics": "~5.6.0",
+        "greybel-gh-mock-intrinsics": "~5.6.1",
+        "greybel-intrinsics": "~5.6.1",
         "greybel-languageserver": "~2.1.1",
         "greybel-languageserver-browser": "~2.1.1",
         "greyhack-message-hook-client": "~0.6.10",
         "greyscript-core": "~2.6.0",
-        "greyscript-interpreter": "~2.6.0",
+        "greyscript-interpreter": "~2.6.1",
         "greyscript-meta": "~4.3.2",
         "greyscript-meta-web": "~1.3.3",
         "greyscript-textmate": "~2.0.2",
@@ -4301,20 +4301,20 @@
       }
     },
     "node_modules/greybel-gh-mock-intrinsics": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/greybel-gh-mock-intrinsics/-/greybel-gh-mock-intrinsics-5.6.0.tgz",
-      "integrity": "sha512-rIvzV4rS/WlgT1BTK6oD8vWM6m30YUeEocUOaOIUP5oFu0KeqXh+rZAz0DdZ9odGrozG8zCu/tN3JTvejb5PHg==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/greybel-gh-mock-intrinsics/-/greybel-gh-mock-intrinsics-5.6.1.tgz",
+      "integrity": "sha512-/KKqHaOlqEL4Xr5f3EYFDTIdjQ2fs8x41eeEb/FX9IUHQ63VCb7Ns7lmavtPY1HpMXtZW3MJmt8Azsui70AZQg==",
       "license": "MIT",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
         "greybel-mock-environment": "~2.4.38",
-        "greyscript-interpreter": "~2.6.0"
+        "greyscript-interpreter": "~2.6.1"
       }
     },
     "node_modules/greybel-interpreter": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-5.6.0.tgz",
-      "integrity": "sha512-9JluhLd7Vl9tek9yqqiIhfmqoixoyXmVrSkOzTKb8bfgyKLc9Gnf4+WpCAXlaD2feEs05ereh2VUpDiQCMJQQw==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-5.6.1.tgz",
+      "integrity": "sha512-wb4JU2cEhB1aZrU8jEygCgX0+jk0HZTOEIngc8ApseesSvuPia4Yy1YrGoFydE7XFGKVc6L+fhEDwrT0zG7f3Q==",
       "license": "MIT",
       "dependencies": {
         "greybel-core": "~2.6.0",
@@ -4324,12 +4324,12 @@
       }
     },
     "node_modules/greybel-intrinsics": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/greybel-intrinsics/-/greybel-intrinsics-5.6.0.tgz",
-      "integrity": "sha512-VE4SOlD3sMa3X/Y4DHJycJa7EB6rGLlHggJ6vrimx44pPgifdhzNhMQKWX+HzjhI8F18eSoqrh2q+apUdh0Yeg==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/greybel-intrinsics/-/greybel-intrinsics-5.6.1.tgz",
+      "integrity": "sha512-Lgj2TZc2BqzB8SsUm6v9eHGgAZQfgsCs1Uwhh2gIRD7Ts5RqWAN+RQDm2iYme/QVgoBwMwd6YGEFkIHBCdfTDg==",
       "license": "MIT",
       "dependencies": {
-        "greyscript-interpreter": "~2.6.0",
+        "greyscript-interpreter": "~2.6.1",
         "long": "^5.2.4",
         "xregexp": "^5.1.1"
       }
@@ -4531,12 +4531,12 @@
       }
     },
     "node_modules/greyscript-interpreter": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-2.6.0.tgz",
-      "integrity": "sha512-mqUSkMwWiCxbKPpIswj14VNFctgswO7wDq55dvVcDSTSSUi0DNnZtffOSyUyKzFzH5BrJF3zt05p67dHRYqqdQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-2.6.1.tgz",
+      "integrity": "sha512-YgRyN2d4IH5Kz2KiDsRYYGqi5gZoPuCxZAVHF/Z9hRt78qvqy49AwR6jsRWu8SXKLGHxFYZgFq2ak1QUdhbqAg==",
       "license": "MIT",
       "dependencies": {
-        "greybel-interpreter": "~5.6.0",
+        "greybel-interpreter": "~5.6.1",
         "greyscript-core": "~2.6.0"
       }
     },
@@ -11155,19 +11155,19 @@
       }
     },
     "greybel-gh-mock-intrinsics": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/greybel-gh-mock-intrinsics/-/greybel-gh-mock-intrinsics-5.6.0.tgz",
-      "integrity": "sha512-rIvzV4rS/WlgT1BTK6oD8vWM6m30YUeEocUOaOIUP5oFu0KeqXh+rZAz0DdZ9odGrozG8zCu/tN3JTvejb5PHg==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/greybel-gh-mock-intrinsics/-/greybel-gh-mock-intrinsics-5.6.1.tgz",
+      "integrity": "sha512-/KKqHaOlqEL4Xr5f3EYFDTIdjQ2fs8x41eeEb/FX9IUHQ63VCb7Ns7lmavtPY1HpMXtZW3MJmt8Azsui70AZQg==",
       "requires": {
         "blueimp-md5": "^2.19.0",
         "greybel-mock-environment": "~2.4.38",
-        "greyscript-interpreter": "~2.6.0"
+        "greyscript-interpreter": "~2.6.1"
       }
     },
     "greybel-interpreter": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-5.6.0.tgz",
-      "integrity": "sha512-9JluhLd7Vl9tek9yqqiIhfmqoixoyXmVrSkOzTKb8bfgyKLc9Gnf4+WpCAXlaD2feEs05ereh2VUpDiQCMJQQw==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-5.6.1.tgz",
+      "integrity": "sha512-wb4JU2cEhB1aZrU8jEygCgX0+jk0HZTOEIngc8ApseesSvuPia4Yy1YrGoFydE7XFGKVc6L+fhEDwrT0zG7f3Q==",
       "requires": {
         "greybel-core": "~2.6.0",
         "hyperid": "^3.2.0",
@@ -11176,11 +11176,11 @@
       }
     },
     "greybel-intrinsics": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/greybel-intrinsics/-/greybel-intrinsics-5.6.0.tgz",
-      "integrity": "sha512-VE4SOlD3sMa3X/Y4DHJycJa7EB6rGLlHggJ6vrimx44pPgifdhzNhMQKWX+HzjhI8F18eSoqrh2q+apUdh0Yeg==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/greybel-intrinsics/-/greybel-intrinsics-5.6.1.tgz",
+      "integrity": "sha512-Lgj2TZc2BqzB8SsUm6v9eHGgAZQfgsCs1Uwhh2gIRD7Ts5RqWAN+RQDm2iYme/QVgoBwMwd6YGEFkIHBCdfTDg==",
       "requires": {
-        "greyscript-interpreter": "~2.6.0",
+        "greyscript-interpreter": "~2.6.1",
         "long": "^5.2.4",
         "xregexp": "^5.1.1"
       },
@@ -11327,11 +11327,11 @@
       }
     },
     "greyscript-interpreter": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-2.6.0.tgz",
-      "integrity": "sha512-mqUSkMwWiCxbKPpIswj14VNFctgswO7wDq55dvVcDSTSSUi0DNnZtffOSyUyKzFzH5BrJF3zt05p67dHRYqqdQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-2.6.1.tgz",
+      "integrity": "sha512-YgRyN2d4IH5Kz2KiDsRYYGqi5gZoPuCxZAVHF/Z9hRt78qvqy49AwR6jsRWu8SXKLGHxFYZgFq2ak1QUdhbqAg==",
       "requires": {
-        "greybel-interpreter": "~5.6.0",
+        "greybel-interpreter": "~5.6.1",
         "greyscript-core": "~2.6.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "soerenwehmeier@googlemail.com"
   },
   "icon": "icon.png",
-  "version": "2.6.54",
+  "version": "2.6.55",
   "repository": {
     "type": "git",
     "url": "git@github.com:ayecue/greybel-vs.git"
@@ -709,13 +709,13 @@
     "color-convert": "^2.0.1",
     "crlf-normalize": "^1.0.20",
     "css-color-names": "^1.0.1",
-    "greybel-gh-mock-intrinsics": "~5.6.0",
-    "greybel-intrinsics": "~5.6.0",
+    "greybel-gh-mock-intrinsics": "~5.6.1",
+    "greybel-intrinsics": "~5.6.1",
     "greybel-languageserver": "~2.1.1",
     "greybel-languageserver-browser": "~2.1.1",
     "greyhack-message-hook-client": "~0.6.10",
     "greyscript-core": "~2.6.0",
-    "greyscript-interpreter": "~2.6.0",
+    "greyscript-interpreter": "~2.6.1",
     "greyscript-meta": "~4.3.2",
     "greyscript-meta-web": "~1.3.3",
     "greyscript-textmate": "~2.0.2",


### PR DESCRIPTION
Includes:
- allow overidding of globals, locals and outer in interpreter runtime
- remove check on map.push in case of already existing key to emulate in-game behaviour