### PR TITLE
2.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1800,3 +1800,7 @@ All notable changes to this project will be documented in this file.
 
 - update message-hook to add small delay before running pre and post script when running in-game import with auto-compile to prevent temporary script not existing when trying to execute script, causing the whole import to fail due to the inability to add resources - seems like this was randomly happening rather than a consistent issue - note that you have to update the message-hook in order to get this fix
 - update meta version which contains some formatting changes for the overflow tooltip
+
+## [2.8.5] - 22.09.2025
+
+- add whitespace after colon sign when convering maps to strings in mock env - thanks for the report to [@smiley8D](https://github.com/smiley8D) - related to [#368](https://github.com/ayecue/greybel-vs/issues/368)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greybel-vs",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "greybel-vs",
-      "version": "2.8.4",
+      "version": "2.8.5",
       "dependencies": {
         "@vscode/debugadapter": "^1.68.0",
         "@vscode/debugprotocol": "^1.68.0",
@@ -15,13 +15,13 @@
         "color-convert": "^2.0.1",
         "crlf-normalize": "^1.0.20",
         "css-color-names": "^1.0.1",
-        "greybel-gh-mock-intrinsics": "~5.6.1",
-        "greybel-intrinsics": "~5.6.1",
+        "greybel-gh-mock-intrinsics": "~5.6.2",
+        "greybel-intrinsics": "~5.6.2",
         "greybel-languageserver": "~2.2.1",
         "greybel-languageserver-browser": "~2.2.1",
         "greyhack-message-hook-client": "1.2.1",
         "greyscript-core": "~2.6.0",
-        "greyscript-interpreter": "~2.6.1",
+        "greyscript-interpreter": "~2.6.2",
         "greyscript-meta": "~4.4.4",
         "greyscript-meta-web": "~1.4.3",
         "greyscript-textmate": "~2.0.3",
@@ -5237,20 +5237,20 @@
       }
     },
     "node_modules/greybel-gh-mock-intrinsics": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/greybel-gh-mock-intrinsics/-/greybel-gh-mock-intrinsics-5.6.1.tgz",
-      "integrity": "sha512-/KKqHaOlqEL4Xr5f3EYFDTIdjQ2fs8x41eeEb/FX9IUHQ63VCb7Ns7lmavtPY1HpMXtZW3MJmt8Azsui70AZQg==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/greybel-gh-mock-intrinsics/-/greybel-gh-mock-intrinsics-5.6.2.tgz",
+      "integrity": "sha512-2rtcELdqNXd9IMHUafVlWweTPNpVpdk1FcoN44LbcqR+sTLBT50MgOcTxZt3y0l5nEcF09qoREOUeYJ3RpXOnA==",
       "license": "MIT",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
         "greybel-mock-environment": "~2.4.38",
-        "greyscript-interpreter": "~2.6.1"
+        "greyscript-interpreter": "~2.6.2"
       }
     },
     "node_modules/greybel-interpreter": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-5.6.1.tgz",
-      "integrity": "sha512-wb4JU2cEhB1aZrU8jEygCgX0+jk0HZTOEIngc8ApseesSvuPia4Yy1YrGoFydE7XFGKVc6L+fhEDwrT0zG7f3Q==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/greybel-interpreter/-/greybel-interpreter-5.6.2.tgz",
+      "integrity": "sha512-nz6X5msoi5ZIlpQOsvVhWGAUKhSs0GsxkoJsH9OXUw7NWg+wWZGBtEXahhxph9olA4zJYAHv0c5RoMqpN5hLLA==",
       "license": "MIT",
       "dependencies": {
         "greybel-core": "~2.6.0",
@@ -5260,12 +5260,12 @@
       }
     },
     "node_modules/greybel-intrinsics": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/greybel-intrinsics/-/greybel-intrinsics-5.6.1.tgz",
-      "integrity": "sha512-Lgj2TZc2BqzB8SsUm6v9eHGgAZQfgsCs1Uwhh2gIRD7Ts5RqWAN+RQDm2iYme/QVgoBwMwd6YGEFkIHBCdfTDg==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/greybel-intrinsics/-/greybel-intrinsics-5.6.2.tgz",
+      "integrity": "sha512-4ggNf5t6QrHukwJuLN14bpxanjUy01zTUxcSnLX8r3JgOJzg47k1m3T62L7w/sJPW/oA1HYDyylA2Oq22PNZcg==",
       "license": "MIT",
       "dependencies": {
-        "greyscript-interpreter": "~2.6.1",
+        "greyscript-interpreter": "~2.6.2",
         "long": "^5.2.4",
         "xregexp": "^5.1.1"
       }
@@ -5452,12 +5452,12 @@
       }
     },
     "node_modules/greyscript-interpreter": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-2.6.1.tgz",
-      "integrity": "sha512-YgRyN2d4IH5Kz2KiDsRYYGqi5gZoPuCxZAVHF/Z9hRt78qvqy49AwR6jsRWu8SXKLGHxFYZgFq2ak1QUdhbqAg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/greyscript-interpreter/-/greyscript-interpreter-2.6.2.tgz",
+      "integrity": "sha512-9oDaGsMjxqiwodHuuAd9xdk8Zte+dkq7NRnwc8LAGZCjFDT0mfFz8UL44l217GFadtDSawxk1TBu7KEnIjQDDQ==",
       "license": "MIT",
       "dependencies": {
-        "greybel-interpreter": "~5.6.1",
+        "greybel-interpreter": "~5.6.2",
         "greyscript-core": "~2.6.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "soerenwehmeier@googlemail.com"
   },
   "icon": "icon.png",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "repository": {
     "type": "git",
     "url": "git@github.com:ayecue/greybel-vs.git"
@@ -703,13 +703,13 @@
     "color-convert": "^2.0.1",
     "crlf-normalize": "^1.0.20",
     "css-color-names": "^1.0.1",
-    "greybel-gh-mock-intrinsics": "~5.6.1",
-    "greybel-intrinsics": "~5.6.1",
+    "greybel-gh-mock-intrinsics": "~5.6.2",
+    "greybel-intrinsics": "~5.6.2",
     "greybel-languageserver": "~2.2.1",
     "greybel-languageserver-browser": "~2.2.1",
     "greyhack-message-hook-client": "1.2.1",
     "greyscript-core": "~2.6.0",
-    "greyscript-interpreter": "~2.6.1",
+    "greyscript-interpreter": "~2.6.2",
     "greyscript-meta": "~4.4.4",
     "greyscript-meta-web": "~1.4.3",
     "greyscript-textmate": "~2.0.3",


### PR DESCRIPTION
Includes:
- add whitespace after colon sign when convering maps to strings in mock env - related to [#368](https://github.com/ayecue/greybel-vs/issues/368)